### PR TITLE
SUSTAINING-703: centralized logging

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from dotenv import load_dotenv
 
@@ -40,12 +41,22 @@ class Config:
                 setattr(self, key, value)
 
             except ValueError as e:
-                print(f"Error: {e}")
+                logging.error(f"Error: {e}")
                 raise
 
             except Exception as e:
-                print(f"Unexpected error with environment variable {key}: {e}")
+                logging.error(f"Unexpected error with environment variable {key}: {e}")
                 raise
+
+        log_level = os.getenv("LOG_LEVEL", "INFO")
+        self.log_level = log_level.upper()
+
+        self.setup_logging()
+
+    def setup_logging(self):
+        log_format = "[%(asctime)s %(levelname)s %(name)s] %(message)s"
+
+        logging.basicConfig(level=self.log_level, format=log_format)
 
 
 config = Config()

--- a/slack_main.py
+++ b/slack_main.py
@@ -2,6 +2,7 @@ from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 from config import config
 import re
+import logging
 
 from slack_handlers.handlers import (
     handle_help,
@@ -10,6 +11,8 @@ from slack_handlers.handlers import (
     handle_create_aws_vm,
     handle_list_aws_vms,
 )
+
+logger = logging.getLogger(__name__)
 
 app = App(token=config.SLACK_BOT_TOKEN)
 
@@ -58,6 +61,6 @@ def mention_handler(body, say):
 
 # Main Entry Point
 if __name__ == "__main__":
-    print("Starting Slack bot...")
+    logger.info("Starting Slack bot...")
     handler = SocketModeHandler(app, config.SLACK_APP_TOKEN)
     handler.start()


### PR DESCRIPTION
### What was done?
This is the first iteration for this task.
In these changes, a common logger has been added to be used in the SlackBot, expose the log level in the `config.py`, and replace a `print` with the `logger` as an example.

The log level is not a number, they are `INFO`, `WARN`, `ERROR`, or `DEBUG`.

### Notes
- I will replace the others `print` in the code after this PR