### PR TITLE
feat: Add OpenStack VM listing functionality

### DIFF
--- a/sdk/openstack/core.py
+++ b/sdk/openstack/core.py
@@ -12,7 +12,6 @@ class OpenStackHelper:
     ):
         self.conn = connection.Connection(
             auth_url=config.OS_AUTH_URL,
-            project_id=config.OS_PROJECT_ID,
             application_credential_id=config.OS_APP_CRED_ID,
             application_credential_secret=config.OS_APP_CRED_SECRET,
             region_name=config.OS_REGION_NAME,
@@ -21,11 +20,59 @@ class OpenStackHelper:
             auth_type=config.OS_AUTH_TYPE,
         )
 
-    def list_servers(self):
+    def list_servers(self, status_filter="ACTIVE"):
         """
-        List all servers in OpenStack.
+        List all OpenStack VMs, optionally filtered by status (e.g., 'ACTIVE', 'SHUTOFF').
+        Returns a list of dictionaries with basic VM info.
         """
-        return [server.name for server in self.conn.compute.servers()]
+        servers_info = []
+        try:
+            # Iterate through all servers
+            for server in self.conn.compute.servers():
+                if status_filter and server.status != status_filter:
+                    continue
+
+                # Initialize IP-related fields
+                networks = server.addresses or {}
+                ip_addr, ip_version, net_name = None, None, None
+
+                # Prioritize floating IP, fallback to fixed if not available
+                for net, ips in networks.items():
+                    for ip_info in ips:
+                        if ip_info.get("OS-EXT-IPS:type") == "floating":
+                            ip_addr = ip_info.get("addr")
+                            ip_version = ip_info.get("version")
+                            net_name = net
+                            break
+                        elif not ip_addr and ip_info.get("OS-EXT-IPS:type") == "fixed":
+                            ip_addr = ip_info.get("addr")
+                            ip_version = ip_info.get("version")
+                            net_name = net
+
+                # Collect server details
+                servers_info.append(
+                    {
+                        "name": server.name,
+                        "server_id": server.id,
+                        "flavor": server.flavor.get("original_name")
+                        or server.flavor.get("id"),
+                        "availability_zone": server.availability_zone,
+                        "network": net_name,
+                        "ip_version": ip_version,
+                        "public_ip": ip_addr,
+                        "key_name": getattr(server, "key_name", "N/A"),
+                        "status": server.status,
+                    }
+                )
+
+            print(
+                f"[OpenStackHelper] Retrieved {len(servers_info)} servers with status='{status_filter}'"
+            )
+            return servers_info
+
+        except Exception as e:
+            print(f"[OpenStackHelper] Error listing servers: {e}")
+            return []
 
     def create_vm(self, args):
         """

--- a/slack_handlers/handlers.py
+++ b/slack_handlers/handlers.py
@@ -22,6 +22,27 @@ def handle_create_openstack_vm(say, user, text):
         say(f"An error occurred creating the openstack VM : {e}")
 
 
+# Helper function to list OpenStack VMs with error handling
+def handle_list_openstack_vms(say):
+    try:
+        helper = OpenStackHelper()
+        servers = helper.list_servers()
+
+        if not servers:
+            say(":no_entry_sign: There are currently *no ACTIVE VMs* in OpenStack.")
+            return
+
+        result = {"count": len(servers), "instances": servers}
+
+        say("*OpenStack ACTIVE VMs:*")
+        say(f"```{result}```")
+
+    except Exception as e:
+        # Log the error for debugging purposes
+        print(f"[ERROR] Failed to list OpenStack VMs: {e}")
+        say(":x: An error occurred while fetching the list of VMs.")
+
+
 # Helper function to handle greeting
 def handle_hello(say, user):
     say(f"Hello <@{user}>! How can I assist you today?")

--- a/slack_main.py
+++ b/slack_main.py
@@ -6,6 +6,7 @@ import re
 from slack_handlers.handlers import (
     handle_help,
     handle_create_openstack_vm,
+    handle_list_openstack_vms,
     handle_hello,
     handle_create_aws_vm,
     handle_list_aws_vms,
@@ -39,6 +40,7 @@ def mention_handler(body, say):
             r"^create-openstack-vm": lambda: handle_create_openstack_vm(
                 say, user, text
             ),
+            r"\blist-openstack-vms\b": lambda: handle_list_openstack_vms(say),
             r"\bhello\b": lambda: handle_hello(say, user),
             r"\bcreate-aws-vm\b": lambda: handle_create_aws_vm(say, user, region),
             r"\blist-aws-vms\b": lambda: handle_list_aws_vms(say, region),


### PR DESCRIPTION
This PR improves the OpenStack VM listing functionality by refining the retrieval and display of VM information, including public IPs and network details.

User: @ocp-sustaining-bot list-openstack-vms
Response: 
{'count': xx, 'instances': [{'name': 'my-vm', 'server_id': '0adxxxxxxx', 'flavor': 'ocp-xxxx-xxx', 'availability_zone': 'nova', 'network': 'xxxxx', 'ip_version': 4, 'public_ip': 'xx.x.xxx.xxx', 'key_name': 'key', 'status': 'ACTIVE'}]}