### PR TITLE
SUSTAINING-703: centralized logging for API

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,25 @@
+import logging
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class Config:
+    """
+    Config class to load and validate environment variables.
+    """
+
+    def __init__(self):
+        log_level = os.getenv("LOG_LEVEL_API", "INFO")
+        self.log_level = log_level.upper()
+
+        self.setup_logging()
+
+    def setup_logging(self):
+        log_format = "[%(asctime)s %(levelname)s %(name)s] %(message)s"
+
+        logging.basicConfig(level=self.log_level, format=log_format)
+
+
+config = Config()


### PR DESCRIPTION
### What was done?
Add centralized logging for the API, it was required to create a `config.py` which is not being called at the moment. 