### PR TITLE
SUSTAINING-791 - list-aws-vms - handle filters if present in the command line

### DIFF
--- a/sdk/aws/ec2.py
+++ b/sdk/aws/ec2.py
@@ -1,6 +1,9 @@
 import boto3
 from config import config
 from sdk.tools.helpers import get_values_for_key_from_dict_of_parameters
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class EC2Helper:
@@ -44,8 +47,7 @@ class EC2Helper:
 
             response = ec2.describe_instances(InstanceIds=instance_ids, Filters=filters)
         except Exception as e:
-            # TODO: replace print with log error
-            print(f"Unable to get instances description from AWS: {e}")
+            logger.error(f"Unable to get instances description from AWS: {e}")
             raise e
 
         instances_info = []
@@ -106,7 +108,7 @@ class EC2Helper:
             instances = ec2.create_instances(**instance_params)
             if instances and len(instances > 0):
                 server_name = instances[0].id
-                print(f"Server {server_name} created successfully")
+                logger.info(f"Server {server_name} created successfully")
                 server_info = {
                     "name": server_name,
                     "key_name": key_name,
@@ -117,6 +119,5 @@ class EC2Helper:
                     "instances": [server_info],
                 }
         except Exception as e:
-            # TODO: replace print with log error
-            print(f"An error occurred creating the EC2 instance {e}")
+            logger.error(f"An error occurred creating the EC2 instance {e}")
             raise e

--- a/sdk/aws/ec2.py
+++ b/sdk/aws/ec2.py
@@ -1,6 +1,6 @@
 import boto3
 from config import config
-from tools.helpers import get_values_for_key_from_dict_of_parameters
+from sdk.tools.helpers import get_values_for_key_from_dict_of_parameters
 
 
 class EC2Helper:
@@ -24,18 +24,18 @@ class EC2Helper:
 
             # instance ids to retrieve
             instance_ids = get_values_for_key_from_dict_of_parameters(
-                "--instance-ids", params_dict
+                "instance-ids", params_dict
             )
 
             filters = []
             state_filters = get_values_for_key_from_dict_of_parameters(
-                "--state", params_dict
+                "state", params_dict
             )
             if state_filters:
                 filters.append({"Name": "instance-state-name", "Values": state_filters})
 
             instance_type_filters = get_values_for_key_from_dict_of_parameters(
-                "--type", params_dict
+                "type", params_dict
             )
             if instance_type_filters:
                 filters.append(

--- a/sdk/tools/helpers.py
+++ b/sdk/tools/helpers.py
@@ -15,7 +15,8 @@ def get_dict_of_command_parameters(command_line: str, texts_to_remove=None):
         if len(valid_cmd_strings) > 1:
             valid_cmd_strings = valid_cmd_strings[1:]
             command_params_dict = dict(
-                (k.replace('--',''), v) for k, v in (pair.split("=") for pair in valid_cmd_strings)
+                (k.replace("--", ""), v)
+                for k, v in (pair.split("=") for pair in valid_cmd_strings)
             )
     return command_params_dict
 

--- a/sdk/tools/helpers.py
+++ b/sdk/tools/helpers.py
@@ -1,4 +1,4 @@
-def get_dict_of_command_parameters(command_line: str, texts_to_remove=None):
+def get_dict_of_command_parameters(command_line: str):
     """
     Given
     1. command_line - the command line e.g. list-aws-vms --type=t3.micro,t2.micro --state=pending,stopped

--- a/sdk/tools/helpers.py
+++ b/sdk/tools/helpers.py
@@ -2,23 +2,21 @@ def get_dict_of_command_parameters(command_line: str, texts_to_remove=None):
     """
     Given
     1. command_line - the command line e.g. list-aws-vms --type=t3.micro,t2.micro --state=pending,stopped
-    2. texts_to_remove - the list of strings to remove e.g. ['list-aws-vms']
-
-    3. remove the command parameter specified in the texts_to_remove list e.g. ['list-aws-vms']
+    2. remove the main command parameter specified in the command line
     4. parse the remaining text and return a dictionary of parameters and a list of associated values if present else {}
-       For example, {'--state': 'pending,stopped', '--type': 't3.micro,t2.micro'}
+       For example, {'state': 'pending,stopped', 'type': 't3.micro,t2.micro'}
     """
     command_params_dict = {}
     if command_line and isinstance(command_line, str):
-        if texts_to_remove and isinstance(texts_to_remove, list):
-            for text_to_remove in texts_to_remove:
-                command_line = command_line.replace(text_to_remove, "")
         sub_params = command_line.split(" ")
         # remove any empty strings which will be there if there were > 1 spaces between parameters
         valid_cmd_strings = [sub_param for sub_param in sub_params if sub_param != ""]
-        command_params_dict = dict(
-            (k, v) for k, v in (pair.split("=") for pair in valid_cmd_strings)
-        )
+        # skip over the 1st value as this will be the main command e.g. list-aws-vms
+        if len(valid_cmd_strings) > 1:
+            valid_cmd_strings = valid_cmd_strings[1:]
+            command_params_dict = dict(
+                (k.replace('--',''), v) for k, v in (pair.split("=") for pair in valid_cmd_strings)
+            )
     return command_params_dict
 
 
@@ -26,8 +24,8 @@ def get_values_for_key_from_dict_of_parameters(key_name: str, dict_of_parameters
     """
     Given
     1. dict_of_parameters - a dictionary of parameters and associated values e.g.
-       {'--state': 'pending,stopped', '--type': 't3.micro,t2.micro'}
-    2. key_name - the key name e.g. '--state'
+       {'state': 'pending,stopped', 'type': 't3.micro,t2.micro'}
+    2. key_name - the key name e.g. 'state'
     Return the list of values associated with the key e.g. ['pending', 'stopped'] if present or else []
     """
     list_of_values = []

--- a/slack_handlers/handlers.py
+++ b/slack_handlers/handlers.py
@@ -1,5 +1,6 @@
 from sdk.aws.ec2 import EC2Helper
 from sdk.openstack.core import OpenStackHelper
+from tools.helpers import get_dict_of_command_parameters
 
 
 # Helper function to handle the "help" command
@@ -51,10 +52,12 @@ def handle_create_aws_vm(say, user, region):
 
 
 # Helper function to list AWS EC2 instances
-def handle_list_aws_vms(say, region):
+def handle_list_aws_vms(say, region, user, text):
     try:
+        params_dict = get_dict_of_command_parameters(text, ["list-aws-vms"])
+
         ec2_helper = EC2Helper(region=region)  # Set your region
-        instances_dict = ec2_helper.list_instances(state_filter="running")
+        instances_dict = ec2_helper.list_instances(params_dict)
         count_servers = instances_dict.get("count", 0)
         if count_servers == 0:
             say("There are currently no running EC2 instances to retrieve")

--- a/slack_handlers/handlers.py
+++ b/slack_handlers/handlers.py
@@ -1,6 +1,6 @@
 from sdk.aws.ec2 import EC2Helper
 from sdk.openstack.core import OpenStackHelper
-from tools.helpers import get_dict_of_command_parameters
+from sdk.tools.helpers import get_dict_of_command_parameters
 
 
 # Helper function to handle the "help" command
@@ -52,15 +52,16 @@ def handle_create_aws_vm(say, user, region):
 
 
 # Helper function to list AWS EC2 instances
-def handle_list_aws_vms(say, region, user, text):
+def handle_list_aws_vms(say, region, user, command_line):
     try:
-        params_dict = get_dict_of_command_parameters(text, ["list-aws-vms"])
+        params_dict = get_dict_of_command_parameters(command_line)
 
         ec2_helper = EC2Helper(region=region)  # Set your region
         instances_dict = ec2_helper.list_instances(params_dict)
         count_servers = instances_dict.get("count", 0)
         if count_servers == 0:
-            say("There are currently no running EC2 instances to retrieve")
+            msg = "There are currently no EC2 instances available that match the specified criteria" if len(params_dict) > 0 else "There are currently no EC2 instances to retrieve"
+            say(msg)
         else:
             for instance_info in instances_dict.get("instances", []):
                 # TODO - format each dictionary element

--- a/slack_handlers/handlers.py
+++ b/slack_handlers/handlers.py
@@ -60,7 +60,11 @@ def handle_list_aws_vms(say, region, user, command_line):
         instances_dict = ec2_helper.list_instances(params_dict)
         count_servers = instances_dict.get("count", 0)
         if count_servers == 0:
-            msg = "There are currently no EC2 instances available that match the specified criteria" if len(params_dict) > 0 else "There are currently no EC2 instances to retrieve"
+            msg = (
+                "There are currently no EC2 instances available that match the specified criteria"
+                if len(params_dict) > 0
+                else "There are currently no EC2 instances to retrieve"
+            )
             say(msg)
         else:
             for instance_info in instances_dict.get("instances", []):

--- a/slack_main.py
+++ b/slack_main.py
@@ -44,7 +44,7 @@ def mention_handler(body, say):
             ),
             r"\bhello\b": lambda: handle_hello(say, user),
             r"\bcreate-aws-vm\b": lambda: handle_create_aws_vm(say, user, region),
-            r"\blist-aws-vms\b": lambda: handle_list_aws_vms(say, region),
+            r"\blist-aws-vms\b": lambda: handle_list_aws_vms(say, region, user, text),
         }
 
         # Check for command matches and execute the appropriate handler

--- a/slack_main.py
+++ b/slack_main.py
@@ -44,7 +44,9 @@ def mention_handler(body, say):
             ),
             r"\bhello\b": lambda: handle_hello(say, user),
             r"\bcreate-aws-vm\b": lambda: handle_create_aws_vm(say, user, region),
-            r"\blist-aws-vms\b": lambda: handle_list_aws_vms(say, region, user, command_line),
+            r"\blist-aws-vms\b": lambda: handle_list_aws_vms(
+                say, region, user, command_line
+            ),
         }
 
         # Check for command matches and execute the appropriate handler

--- a/slack_main.py
+++ b/slack_main.py
@@ -22,10 +22,10 @@ app = App(token=config.SLACK_BOT_TOKEN)
 @app.event("message")
 def mention_handler(body, say):
     user = body.get("event", {}).get("user")
-    text = body.get("event", {}).get("text", "").strip()
+    command_line = body.get("event", {}).get("text", "").strip()
     region = config.AWS_DEFAULT_REGION
 
-    cmd_strings = text.split(" ")
+    cmd_strings = command_line.split(" ")
     if len(cmd_strings) > 0:
         first_command = cmd_strings[0]
         if first_command[:2] == "<@":
@@ -35,21 +35,21 @@ def mention_handler(body, say):
         valid_cmd_strings = [
             sub_string for sub_string in cmd_strings if sub_string != ""
         ]
-        text = " ".join(valid_cmd_strings)
+        command_line = " ".join(valid_cmd_strings)
         # Create a command mapping
         commands = {
             r"\bhelp\b": lambda: handle_help(say, user),
             r"^create-openstack-vm": lambda: handle_create_openstack_vm(
-                say, user, text
+                say, user, command_line
             ),
             r"\bhello\b": lambda: handle_hello(say, user),
             r"\bcreate-aws-vm\b": lambda: handle_create_aws_vm(say, user, region),
-            r"\blist-aws-vms\b": lambda: handle_list_aws_vms(say, region, user, text),
+            r"\blist-aws-vms\b": lambda: handle_list_aws_vms(say, region, user, command_line),
         }
 
         # Check for command matches and execute the appropriate handler
         for pattern, handler in commands.items():
-            if re.search(pattern, text, re.IGNORECASE):
+            if re.search(pattern, command_line, re.IGNORECASE):
                 handler()  # Execute the handler
                 return
 

--- a/tools/helpers.py
+++ b/tools/helpers.py
@@ -1,0 +1,43 @@
+def get_dict_of_command_parameters(command_line: str, texts_to_remove=None):
+    """
+    Given
+    1. command_line - the command line e.g. list-aws-vms --type=t3.micro,t2.micro --state=pending,stopped
+    2. texts_to_remove - the list of strings to remove e.g. ['list-aws-vms']
+
+    3. remove the command parameter specified in the texts_to_remove list e.g. ['list-aws-vms']
+    4. parse the remaining text and return a dictionary of parameters and a list of associated values if present else {}
+       For example, {'--state': 'pending,stopped', '--type': 't3.micro,t2.micro'}
+    """
+    command_params_dict = {}
+    if command_line and isinstance(command_line, str):
+        if texts_to_remove and isinstance(texts_to_remove, list):
+            for text_to_remove in texts_to_remove:
+                command_line = command_line.replace(text_to_remove, "")
+        sub_params = command_line.split(" ")
+        # remove any empty strings which will be there if there were > 1 spaces between parameters
+        valid_cmd_strings = [sub_param for sub_param in sub_params if sub_param != ""]
+        command_params_dict = dict(
+            (k, v) for k, v in (pair.split("=") for pair in valid_cmd_strings)
+        )
+    return command_params_dict
+
+
+def get_values_for_key_from_dict_of_parameters(key_name: str, dict_of_parameters: dict):
+    """
+    Given
+    1. dict_of_parameters - a dictionary of parameters and associated values e.g.
+       {'--state': 'pending,stopped', '--type': 't3.micro,t2.micro'}
+    2. key_name - the key name e.g. '--state'
+    Return the list of values associated with the key e.g. ['pending', 'stopped'] if present or else []
+    """
+    list_of_values = []
+    if (
+        key_name
+        and dict_of_parameters
+        and isinstance(key_name, str)
+        and isinstance(dict_of_parameters, dict)
+    ):
+        values = dict_of_parameters.get(key_name, None)
+        if values and isinstance(values, str):
+            list_of_values = [value.strip() for value in values.split(",")]
+    return list_of_values


### PR DESCRIPTION
list-aws-vms:
Code now handles filtering on
1. instance-ids
2. state
3. type
For example:
@ocp-sustaining-bot list-aws-vms --instance-ids=i-091371b1dd06cff20 --type=t3.micro,t2.micro --state=pending,stopped

![image](https://github.com/user-attachments/assets/2d5aa545-a8e1-4afa-b6e9-86e64130f4fd)

To do:
Formatting the response data in Slack