### PR TITLE
SUSTAINING-839: fix create_instance condition on aws sdk

### DIFF
--- a/sdk/aws/ec2.py
+++ b/sdk/aws/ec2.py
@@ -88,18 +88,27 @@ class EC2Helper:
                 instance_params["SubnetId"] = subnet_id
 
             instances = ec2.create_instances(**instance_params)
-            if instances and len(instances > 0):
-                server_name = instances[0].id
-                logger.info(f"Server {server_name} created successfully")
-                server_info = {
-                    "name": server_name,
-                    "key_name": key_name,
-                    "instance_type": instance_type,
-                }
+
+            if not instances:
+                logger.warning(f"Unable to create EC2 instance: {instance_params}")
+
                 return {
-                    "count": 1,
-                    "instances": [server_info],
+                    "count": 0,
+                    "instances": [],
                 }
+
+            server_name = instances[0].id
+            logger.info(f"Server {server_name} created successfully")
+            server_info = {
+                "name": server_name,
+                "key_name": key_name,
+                "instance_type": instance_type,
+            }
+
+            return {
+                "count": 1,
+                "instances": [server_info],
+            }
         except Exception as e:
             logger.error(f"An error occurred creating the EC2 instance {e}")
             raise e


### PR DESCRIPTION
The condition is causing an error because the `instances` is an `array` and not a `int`.
The code proposed should fix the issue, also it will log a warning and return an empty data that should be handled in the bot handlers.

With the current code, it's also shifting the code nested in the condition block to the outside, which makes it simpler.

**Note:** in Python it's not needed to use `len` to check if the array is empty, you can just check the array variable. It also works when using the `not` operator.