### PR TITLE
list AWS EC2 instances in slack in a table like format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ python-dotenv
 slack-bolt
 aiohttp
 pytest
-pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv
 slack-bolt
 aiohttp
 pytest
+pandas

--- a/sdk/aws/ec2.py
+++ b/sdk/aws/ec2.py
@@ -79,6 +79,7 @@ class EC2Helper:
                         "key_name": instance.get("KeyName", ""),
                         "vpc_id": instance.get("VpcId", ""),
                         "public_ip": instance.get("PublicIpAddress", "N/A"),
+                        "private_ip": instance.get("PrivateIpAddress", "N/A"),
                         "state": instance_state_name,
                     }
                     instances_info.append(instance_info)

--- a/slack_handlers/handlers.py
+++ b/slack_handlers/handlers.py
@@ -104,7 +104,7 @@ def handle_create_aws_vm(say, user, region):
         say("An internal error occurred, please contact administrator.")
 
 
-def create_table(data_rows, table_column_names, max_column_widths):
+def helper_create_table(data_rows, table_column_names, max_column_widths):
     """
     Given
      1. data_rows - a list of row data to display
@@ -138,7 +138,7 @@ def create_table(data_rows, table_column_names, max_column_widths):
     return f"```\n{table}\n```"
 
 
-def setup_slack_header_line(header_text, emoji_name="ledger"):
+def helper_setup_slack_header_line(header_text, emoji_name="ledger"):
     """
     sets up a slack block consisting of an emoji and bold text. This is typically used for a header line
     """
@@ -170,7 +170,9 @@ def helper_display_dict_output_as_table(instances_dict, data_key_names, say):
     if instances_dict and isinstance(instances_dict, dict) and len(instances_dict) > 0:
         say(
             text=".",
-            blocks=setup_slack_header_line(" Here are the requested VM instances:"),
+            blocks=helper_setup_slack_header_line(
+                " Here are the requested VM instances:"
+            ),
         )
         max_column_widths = {}
         rows = []
@@ -191,7 +193,7 @@ def helper_display_dict_output_as_table(instances_dict, data_key_names, say):
                     max_column_widths[data_key_name] = len(column_value)
                 row.append(column_value)
             rows.append(row)
-        say(create_table(rows, data_key_names, max_column_widths))
+        say(helper_create_table(rows, data_key_names, max_column_widths))
 
 
 # Helper function to list AWS EC2 instances

--- a/slack_handlers/handlers.py
+++ b/slack_handlers/handlers.py
@@ -162,7 +162,7 @@ def setup_slack_header_line(header_text, emoji_name="ledger"):
     ]
 
 
-def helper_display_dict_output_as_table(instances_dict, say):
+def helper_display_dict_output_as_table(instances_dict, data_key_names, say):
     """
     given a dictionary containing instance information for servers, set up a header line and then display the data in
     a "table"
@@ -172,14 +172,6 @@ def helper_display_dict_output_as_table(instances_dict, say):
             text=".",
             blocks=setup_slack_header_line(" Here are the requested VM instances:"),
         )
-        data_key_names = [
-            "instance_id",
-            "name",
-            "instance_type",
-            "state",
-            "public_ip",
-            "private_ip",
-        ]
         max_column_widths = {}
         rows = []
 
@@ -218,7 +210,15 @@ def handle_list_aws_vms(say, region, user, command_line):
             )
             say(msg)
         else:
-            helper_display_dict_output_as_table(instances_dict, say)
+            data_key_names = [
+                "instance_id",
+                "name",
+                "instance_type",
+                "state",
+                "public_ip",
+                "private_ip",
+            ]
+            helper_display_dict_output_as_table(instances_dict, data_key_names, say)
     except Exception as e:
         logger.error(f"An error occurred listing the EC2 instances: {e}")
         say("An internal error occurred, please contact administrator.")

--- a/slack_handlers/handlers.py
+++ b/slack_handlers/handlers.py
@@ -162,7 +162,7 @@ def helper_setup_slack_header_line(header_text, emoji_name="ledger"):
     ]
 
 
-def helper_display_dict_output_as_table(instances_dict, data_key_names, say):
+def helper_display_dict_output_as_table(instances_dict, print_keys, say):
     """
     given a dictionary containing instance information for servers, set up a header line and then display the data in
     a "table"
@@ -181,19 +181,19 @@ def helper_display_dict_output_as_table(instances_dict, data_key_names, say):
         # storing it in a dictionary
 
         # initially set the max length for each column to the column header name
-        for data_key_name in data_key_names:
+        for data_key_name in print_keys:
             max_column_widths[data_key_name] = len(data_key_name)
 
         for instance_info in instances_dict.get("instances", []):
             row = []
-            for data_key_name in data_key_names:
+            for data_key_name in print_keys:
                 column_value = instance_info.get(data_key_name, "unknown")
                 current_max_len = max_column_widths.get(data_key_name, 0)
                 if len(column_value) > current_max_len:
                     max_column_widths[data_key_name] = len(column_value)
                 row.append(column_value)
             rows.append(row)
-        say(helper_create_table(rows, data_key_names, max_column_widths))
+        say(helper_create_table(rows, print_keys, max_column_widths))
 
 
 # Helper function to list AWS EC2 instances
@@ -212,7 +212,7 @@ def handle_list_aws_vms(say, region, user, command_line):
             )
             say(msg)
         else:
-            data_key_names = [
+            print_keys = [
                 "instance_id",
                 "name",
                 "instance_type",
@@ -220,7 +220,7 @@ def handle_list_aws_vms(say, region, user, command_line):
                 "public_ip",
                 "private_ip",
             ]
-            helper_display_dict_output_as_table(instances_dict, data_key_names, say)
+            helper_display_dict_output_as_table(instances_dict, print_keys, say)
     except Exception as e:
         logger.error(f"An error occurred listing the EC2 instances: {e}")
         say("An internal error occurred, please contact administrator.")


### PR DESCRIPTION
The code now lists EC2 instances in a table like structure in the Slack message.
For example:
![image](https://github.com/user-attachments/assets/cf950dcc-8aef-40a2-b30e-1d6fcb4eaa1a)
