### PR TITLE
SUSTAINING-853: tests step on GitHub workflow

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -41,26 +41,38 @@ jobs:
             echo "✅ No .env files detected."
           fi
 
-  # run-entrypoint:
-  #   name: Test Python Entrypoint
-  #   runs-on: ubuntu-latest
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout Code
-  #       uses: actions/checkout@v3
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: 3.12
+      - name: Get changed files
+        id: changed
+        run: |
+          echo "CHANGED=$(git diff --name-only origin/${{ github.base_ref }} | tr '\n' ' ')" >> $GITHUB_ENV
 
-  #     - name: Install Dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         # Install project dependencies 
-  #         pip install -r requirements.txt
+      - name: Setup python requirements
+        if: contains(env.CHANGED, 'sdk/') || contains(env.CHANGED, 'tests/')
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
-  #     - name: Run Entrypoint 
-  #       run: |
-  #          export $(grep -v '^#' vars | xargs)
-  #          python -c "import slack_main" || exit 1
+      - name: Test SDK AWS
+        if: contains(env.CHANGED, 'sdk/aws/') || contains(env.CHANGED, 'tests/')
+        run: |
+          python -m pytest sdk/tests/test_runner.py::TestRunner::test_aws
+
+      - name: Test SDK OpenStack
+        if: contains(env.CHANGED, 'sdk/openstack/') || contains(env.CHANGED, 'tests/')
+        run: |
+          python -m pytest sdk/tests/test_runner.py::TestRunner::test_openstack
+
+      - name: Test SDK Tools
+        if: contains(env.CHANGED, 'sdk/tools/') || contains(env.CHANGED, 'tests/')
+        run: |
+          python -m pytest sdk/tests/test_runner.py::TestRunner::test_tools

--- a/sdk/tests/conftest.py
+++ b/sdk/tests/conftest.py
@@ -1,0 +1,24 @@
+import os
+
+import pytest
+
+pytest_plugins = [
+    "pytester",
+]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_environment_variables():
+    os.environ["SLACK_BOT_TOKEN"] = "SLACK_BOT_TOKEN"
+    os.environ["SLACK_APP_TOKEN"] = "SLACK_APP_TOKEN"
+    os.environ["AWS_ACCESS_KEY_ID"] = "AWS_ACCESS_KEY_ID"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "AWS_SECRET_ACCESS_KEY"
+    os.environ["AWS_DEFAULT_REGION"] = "AWS_DEFAULT_REGION"
+    os.environ["OS_AUTH_URL"] = "OS_AUTH_URL"
+    os.environ["OS_PROJECT_ID"] = "OS_PROJECT_ID"
+    os.environ["OS_INTERFACE"] = "OS_INTERFACE"
+    os.environ["OS_ID_API_VERSION"] = "OS_ID_API_VERSION"
+    os.environ["OS_REGION_NAME"] = "OS_REGION_NAME"
+    os.environ["OS_APP_CRED_ID"] = "OS_APP_CRED_ID"
+    os.environ["OS_APP_CRED_SECRET"] = "OS_APP_CRED_SECRET"
+    os.environ["OS_AUTH_TYPE"] = "v3applicationcredential"

--- a/sdk/tests/test_runner.py
+++ b/sdk/tests/test_runner.py
@@ -1,0 +1,39 @@
+from pytest import Pytester
+
+
+class TestRunner(object):
+    def test_aws(self, pytester: Pytester) -> None:
+        pytester.copy_example("tests/test_aws.py")
+        result = pytester.runpytest()
+        outcomes = result.parseoutcomes()
+        assert "failed" not in outcomes.keys(), (
+            f"{outcomes['failed']} unit tests failed."
+        )
+        assert "errors" not in outcomes.keys(), (
+            f"{outcomes['errors']} unit tests have errors."
+        )
+        assert "passed" in outcomes.keys(), "No tests passed."
+
+    def test_openstack(self, pytester: Pytester) -> None:
+        pytester.copy_example("tests/test_openstack.py")
+        result = pytester.runpytest()
+        outcomes = result.parseoutcomes()
+        assert "failed" not in outcomes.keys(), (
+            f"{outcomes['failed']} unit tests failed."
+        )
+        assert "errors" not in outcomes.keys(), (
+            f"{outcomes['errors']} unit tests have errors."
+        )
+        assert "passed" in outcomes.keys(), "No tests passed."
+
+    def test_tools(self, pytester: Pytester) -> None:
+        pytester.copy_example("tests/test_tools.py")
+        result = pytester.runpytest()
+        outcomes = result.parseoutcomes()
+        assert "failed" not in outcomes.keys(), (
+            f"{outcomes['failed']} unit tests failed."
+        )
+        assert "errors" not in outcomes.keys(), (
+            f"{outcomes['errors']} unit tests have errors."
+        )
+        assert "passed" in outcomes.keys(), "No tests passed."


### PR DESCRIPTION
### What is done?

Adding the tests step on GitHub workflow to run the tests and make sure new changes will no break the existing changes.
For now since there is tests only for the SDK, it's only applying to it.

Also, I have created a test runner that will setup fake values into the required environment variables before call the tests. It's not possible to run the tests without it because the `config` initialization is done at the `import` which occurs before the test fixtures.

### Additional notes
- Created a new GitHub workflow to be use the `path`, the new workflow will only run for changes on `sdk/`
- Fixed tests aws