### PR TITLE
python version freeze

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-boto3
-openshift
-openstacksdk
-requests
-python-dotenv
-slack-bolt
-aiohttp
-pytest
+boto3==1.38.18
+openshift==0.13.2
+openstacksdk==4.5.0
+requests==2.32.3
+python-dotenv==1.1.0
+slack_bolt==1.23.0
+aiohttp==3.11.18
+pytest==8.3.5


### PR DESCRIPTION
This is to freeze runtime to : 3.12 
Also to freeze the dependency pkg versions as mentioned in the requirements.txt.
This is important 
- to have same consistent software running across platforms.
- to avoid confusions during reproducibility of issues while debugging
- to have consistent docker builds
