### PR TITLE
aws: allow user to specify the --region parameter if required

### DIFF
--- a/slack_handlers/handlers.py
+++ b/slack_handlers/handlers.py
@@ -126,6 +126,7 @@ def handle_create_aws_vm(say, user, region, command_line):
                 ":hourglass_flowing_sand: Now processing your request for a Linux Instance... Please wait."
             )
 
+            region = command_params.get("region", region)
             # Create EC2 instance using the helper
             ec2_helper = EC2Helper(region=region)
             server_status_dict = ec2_helper.create_instance(
@@ -301,6 +302,7 @@ def helper_display_dict_output_as_table(instances_dict, print_keys, say):
 def handle_list_aws_vms(say, region, user, command_line):
     try:
         params_dict = get_dict_of_command_parameters(command_line)
+        region = params_dict.get("region", region)
 
         ec2_helper = EC2Helper(region=region)  # Set your region
         instances_dict = ec2_helper.list_instances(params_dict)


### PR DESCRIPTION
This is a simple enhancement to allow the user override the region for the commands

list_aws_vms and 

create_aws_vm

(If the user does not specify a region, the default one from the .env file is still used)

In this example:
in the .env file, the region is set to us-east-1:

AWS_DEFAULT_REGION=us-east-1

but the user specifies a different the region in the command line:
![image](https://github.com/user-attachments/assets/39bb5aa2-382b-4800-b0de-9f2cd75a0e43)
