### PR TITLE
Feat / Add Slackbot support for OpenStack VM creation

### DIFF
--- a/sdk/openstack/core.py
+++ b/sdk/openstack/core.py
@@ -1,7 +1,9 @@
 from openstack import connection
+from openstack.exceptions import ResourceNotFound, ResourceFailure
 from config import config
 from sdk.tools.helpers import get_values_for_key_from_dict_of_parameters
 import logging
+import traceback
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +69,7 @@ class OpenStackHelper:
                         "flavor": server.flavor.get("original_name")
                         or server.flavor.get("id"),
                         "network": net_name,
-                        "public_ip": ip_addr,
+                        "private_ip": ip_addr,
                         "key_name": getattr(server, "key_name", "N/A"),
                         "status": server.status,
                     }
@@ -86,36 +88,108 @@ class OpenStackHelper:
             )
             raise e
 
-    def create_vm(self, args):
+    def create_vm(self, params_dict):
         """
-        Create an OpenStack VM with the specified parameters provided as a list of arguments.
+        Create an OpenStack VM with the specified parameters provided as a dictionary.
+        :param params_dict: Dictionary of parameters including 'name', 'image-id', 'flavor', 'network', and 'key_name'.
+        :return: dictionary containing instance details.
+        """
+        required_params = ["name", "image-id", "flavor", "key_name"]
+        missing_params = [
+            param for param in required_params if param not in params_dict
+        ]
 
-        :param args: List of arguments: [name, image, flavor, network]
-        :return: dictionary
-        """
-        if len(args) != 4:
-            logger.error("create-openstack-vm: Invalid parameters supplied")
+        if missing_params:
+            logger.error(
+                f"Missing required parameters for VM creation: {', '.join(missing_params)}"
+            )
             raise ValueError(
-                "Invalid parameters: Usage: `create-openstack-vm <name> <image> <flavor> <network>`"
+                f"Missing required parameters: {', '.join(missing_params)}"
             )
 
-        name, image, flavor, network = args
+        # Extract parameters
+        name = params_dict["name"]
+        image_id = params_dict["image-id"]
+        flavor_name = params_dict["flavor"]
+        key_name = params_dict["key_name"]
+        network = params_dict.get("network", None)
 
-        logger.info(f"Creating OpenStack VM: {name}...")
+        logger.info(
+            f"Creating OpenStack VM: {name} with image {image_id}, flavor {flavor_name}, "
+            f"network {network}, key_name {key_name}"
+        )
+
+        networks_param = [{"uuid": network}] if network else []
+
+        # Validate the provided key_name
+        available_keys = [kp.name for kp in self.conn.compute.keypairs()]
+        if key_name not in available_keys:
+            logger.error(
+                f"Invalid key_name '{key_name}' provided. Available keypairs: {available_keys}"
+            )
+            raise ValueError(
+                f"Invalid key_name '{key_name}' provided. Available keypairs: {available_keys}"
+            )
 
         try:
+            # Resolve flavor by name
+            flavor = self.conn.compute.find_flavor(flavor_name, ignore_missing=False)
+            if not flavor:
+                raise ValueError(f"Flavor '{flavor_name}' not found in OpenStack.")
+
+            # Optionally validate image exists
+            image = self.conn.compute.find_image(image_id, ignore_missing=False)
+            if not image:
+                raise ValueError(f"Image '{image_id}' not found in OpenStack.")
+
             server = self.conn.compute.create_server(
-                name=name, image=image, flavor=flavor, networks=[{"uuid": network}]
+                name=name,
+                image_id=image.id,
+                flavor_id=flavor.id,
+                networks=networks_param,
+                key_name=key_name,
             )
+
+            # Wait for VM to become ACTIVE
+            server = self.conn.compute.wait_for_server(server)
+
             logger.info(f"VM {server.name} created successfully in OpenStack!")
-            # todo: add additional information to server_info dictionary later
+
+            # Extract the first fixed (private) IP address
+            private_ip = None
+            for addr_list in server.addresses.values():
+                for addr in addr_list:
+                    if addr.get("OS-EXT-IPS:type") == "fixed":
+                        private_ip = addr.get("addr")
+                        break
+                if private_ip:
+                    break
+
+            logger.info(f"VM {server.name} is ACTIVE with private IP: {private_ip}")
+
+            # Construct response dictionary
             server_info = {
                 "name": server.name,
+                "server_id": server.id,
+                "status": server.status,
+                "flavor": flavor.name,
+                "network": network or "Default Network",
+                "key_name": key_name,
+                "private_ip": private_ip or "N/A",
             }
+
             return {
                 "count": 1,
                 "instances": [server_info],
             }
+
+        except ResourceFailure as rf:
+            logger.error(f"OpenStack VM transitioned to ERROR state: {str(rf)}")
+            raise RuntimeError(
+                "OpenStack VM provisioning failed. Please verify image/flavor/network configuration."
+            ) from rf
+
         except Exception as e:
             logger.error(f"Error creating OpenStack VM: {str(e)}")
+            logger.error(traceback.format_exc())
             raise e

--- a/slack_handlers/handlers.py
+++ b/slack_handlers/handlers.py
@@ -1,9 +1,31 @@
 from sdk.aws.ec2 import EC2Helper
 from sdk.openstack.core import OpenStackHelper
 from sdk.tools.helpers import get_dict_of_command_parameters
+from dotenv import load_dotenv
+import os
 import logging
 import traceback
 
+# 2. Load .env
+load_dotenv()
+
+# Openstack Configuration mappings
+OS_IMAGE_MAP = {
+    "fedora": os.getenv("OPENSTACK_IMAGE_ID_FEDORA"),
+    "ubuntu": os.getenv("OPENSTACK_IMAGE_ID_UBUNTU"),
+    "centos": os.getenv("OPENSTACK_IMAGE_ID_CENTOS"),
+}
+
+NETWORK_MAP = {
+    "provider_net_lab": os.getenv("OPENSTACK_NETWORK_PROVIDER_NET_LAB"),
+    "provider_net_cci_5": os.getenv("OPENSTACK_NETWORK_PROVIDER_NET_CCI_5"),
+}
+
+DEFAULT_NETWORK = os.getenv("DEFAULT_NETWORK", "provider_net_cci_5")
+DEFAULT_SSH_USER = os.getenv("DEFAULT_SSH_USER", "fedora")
+DEFAULT_KEY_NAME = os.getenv("DEFAULT_KEY_NAME", "ocp-sust-slackbot-keypair")
+
+#
 logger = logging.getLogger(__name__)
 
 
@@ -30,14 +52,116 @@ def handle_help(say, user):
 
 
 # Helper function to handle creating an OpenStack VM
-def handle_create_openstack_vm(say, user, text):
+def handle_create_openstack_vm(say, user, command_line):
     try:
-        args = text.replace("create-openstack-vm", "").strip().split()
-        os_helper = OpenStackHelper()
-        os_helper.create_vm(args)
+        command_params = get_dict_of_command_parameters(command_line)
+
+        # Extract key params from command
+        name = command_params.get("name")
+        os_name = command_params.get("os_name")
+        flavor = command_params.get("flavor")
+        key_name = command_params.get("key_name")
+
+        logger.info(
+            f"Parsed Parameters: name={name}, os_name={os_name}, flavor={flavor}, key_name={key_name}"
+        )
+
+        # Validate required fields
+        required_params = ["name", "os_name", "flavor", "key_name"]
+        missing_params = [
+            param for param in required_params if not command_params.get(param)
+        ]
+
+        if missing_params:
+            say(
+                f":warning: Missing required parameters: {', '.join(missing_params)}. "
+                f"Usage: create-openstack-vm --name=<name> --os_name=<os_name> --flavor=<flavor> --key_name=<key>\n"
+                f"Supported OS names: {', '.join(OS_IMAGE_MAP.keys())}"
+            )
+            return
+
+        # Normalize OS name and retrieve corresponding image ID
+        os_name_lower = os_name.strip().lower()
+        image_id = OS_IMAGE_MAP.get(os_name_lower)
+
+        if not image_id:
+            say(
+                f":x: Unsupported OS name: `{os_name}`. "
+                f"Supported OS names: {', '.join(OS_IMAGE_MAP.keys())}"
+            )
+            return
+
+        # Resolve network ID using default network name
+        network_id = NETWORK_MAP.get(DEFAULT_NETWORK)
+        if not network_id:
+            say(
+                ":x: No valid network ID found for the default network. Please check configuration."
+            )
+            logger.error(f"Missing network ID for default network: {DEFAULT_NETWORK}")
+            return
+
+        logger.info(f"Using Image ID: {image_id} and Network ID: {network_id}")
+
+        # Build request payload for OpenStackHelper
+        params_dict = {
+            "name": name,
+            "image-id": image_id,
+            "flavor": flavor,
+            "key_name": key_name,
+            "network": network_id,
+        }
+
+        say(
+            ":hourglass_flowing_sand: Now processing your request for an OpenStack VM... Please wait."
+        )
+        openstack_helper = OpenStackHelper()
+        response = openstack_helper.create_vm(params_dict)
+
+        # Extract result from response
+        instances = response.get("instances", [])
+        if instances:
+            instance_info = instances[0]
+
+            say(":white_check_mark: *Successfully created OpenStack VM!*\n")
+
+            # Format and display instance metadata as table
+            print_keys = [
+                "name",
+                "server_id",
+                "key_name",
+                "flavor",
+                "network",
+                "status",
+                "private_ip",
+            ]
+            block_message = "Here are the details of your new OpenStack VM:"
+            helper_display_dict_output_as_table(
+                {"instances": [instance_info]}, print_keys, say, block_message
+            )
+
+            # Provide SSH access instructions for user
+            say(
+                f"\n\n"
+                ":key: *Access Instructions (Linux/Unix):*\n"
+                "Use the following command to SSH into your instance:\n"
+                f"`ssh -i <path_to_your_private_key.pem> {DEFAULT_SSH_USER}@{instance_info.get('private_ip', '<Private_IP>')}`\n"
+                "Make sure your key file has the correct permissions: `chmod 400 <path_to_your_private_key.pem>`\n"
+                "\n\n"
+                ":warning: *Key Pair Access:*\n"
+                f"To access this instance via SSH, you should have the `{instance_info.get('key_name', DEFAULT_KEY_NAME)}` private key.\n"
+                "If you don't have it, please contact the admin for access."
+            )
+
+        else:
+            say(":x: VM creation failed. No instance details returned.")
+            logger.error(f"OpenStack VM creation failed: {response}")
+
     except Exception as e:
-        logger.error(f"An error occurred creating the openstack VM : {e}")
-        say("An internal error occurred, please contact administrator.")
+        logger.error(f"Error during OpenStack VM creation: {e}")
+        logger.error(traceback.format_exc())
+        say(
+            ":x: An internal error occurred while creating the OpenStack VM. Please contact the administrator."
+        )
 
 
 # Helper function to list OpenStack VMs with error handling
@@ -47,7 +171,7 @@ def handle_list_openstack_vms(say, command_line=""):
         params_dict = get_dict_of_command_parameters(command_line)
 
         # Define valid status filters
-        VALID_STATUSES = {"ACTIVE", "SHUTOFF"}
+        VALID_STATUSES = {"ACTIVE", "SHUTOFF", "ERROR"}
         # Default to ACTIVE if no status filter provided
         status_filter = params_dict.get("status", "ACTIVE").upper()
 
@@ -81,7 +205,7 @@ def handle_list_openstack_vms(say, command_line=""):
                 "name",
                 "flavor",
                 "network",
-                "public_ip",
+                "private_ip",
                 "key_name",
                 "status",
             ]


### PR DESCRIPTION
- Slack command creates an OpenStack VM with dynamic OS, flavor, key, and network.
- VM info is displayed as a formatted table.
- SSH access instructions are shown with the correct user.
- Image and network IDs are fetched from .env (not hardcoded).
- Default values for SSH user and keypair are configurable.