### PR TITLE
SUSTAINING-1003 support to command flag parameter

### DIFF
--- a/sdk/tests/test_tools.py
+++ b/sdk/tests/test_tools.py
@@ -62,11 +62,6 @@ def test_get_dict_of_command_parameters_when_value_has_spaces():
     assert "pending" == params_dict.get("state")
 
 
-def test_get_dict_of_command_parameters_when_missing_value():
-    params_dict = get_dict_of_command_parameters("list-aws-vms --type")
-    assert "type" not in params_dict
-
-
 def test_get_dict_when_command_has_extra_spaces():
     params_dict = get_dict_of_command_parameters(
         "create-aws-vm   --os_name=linux    --instance_type=t2.micro  --key_pair=my-key"
@@ -92,6 +87,28 @@ def test_get_dict_when_trailing_commas_between_params():
         "create-aws-vm --state=pending,,, stopped,,,, "
     )
     assert "pending,stopped" == params_dict.get("state")
+
+
+def test_get_dict_with_flag_parameters():
+    params_dict = get_dict_of_command_parameters(
+        "aws-modify-vm --stop --vm-id=i-123456"
+    )
+    assert params_dict.get("stop") is True
+    assert params_dict.get("vm-id") == "i-123456"
+
+
+def test_get_dict_with_multiple_flag_parameters():
+    params_dict = get_dict_of_command_parameters("command --flag1 --flag2 --value=test")
+    assert params_dict.get("flag1") is True
+    assert params_dict.get("flag2") is True
+    assert params_dict.get("value") == "test"
+
+
+def test_get_dict_with_only_flag_parameters():
+    params_dict = get_dict_of_command_parameters("command --stop --delete")
+    assert params_dict.get("stop") is True
+    assert params_dict.get("delete") is True
+    assert len(params_dict) == 2
 
 
 def test_get_values_for_key_from_dict_of_parameters_when_empty_dict():

--- a/sdk/tools/helpers.py
+++ b/sdk/tools/helpers.py
@@ -6,9 +6,11 @@ logger = logging.getLogger(__name__)
 
 def get_dict_of_command_parameters(command_line: str) -> dict:
     """
-    Given the command_line e.g. list-aws-vms --type=t3.micro,t2.micro --state=pending,stopped
-    Parse the parameters and return a dictionary of parameters and a list of associated values if present else {}
-       For example, {'state': 'pending,stopped', 'type': 't3.micro,t2.micro'}
+    Given the command_line e.g. list-aws-vms --type=t3.micro,t2.micro --state=pending,stopped --stop
+    Parse the parameters and return a dictionary of parameters and values/flags:
+    - Parameters with values are stored as key-value pairs: {'state': 'pending,stopped', 'type': 't3.micro,t2.micro'}
+    - Flag parameters (without values) are stored as key-boolean pairs: {'stop': True}
+    Returns empty dict {} if no parameters found.
     """
     if not isinstance(command_line, str):
         return {}
@@ -44,10 +46,17 @@ def get_dict_of_command_parameters(command_line: str) -> dict:
                     value = args[i + 1]
                     i += 1  # Skip next token since it's a value
                 key = key.strip()
-                if len(key) > 0 and value not in (None, ""):
-                    parsed_params[key] = (
-                        value.strip() if isinstance(value, str) else str(value).strip()
-                    )
+                if len(key) > 0:
+                    if value not in (None, ""):
+                        # Parameter with value
+                        parsed_params[key] = (
+                            value.strip()
+                            if isinstance(value, str)
+                            else str(value).strip()
+                        )
+                    else:
+                        # Flag parameter without value (e.g., --stop, --delete)
+                        parsed_params[key] = True
             i += 1
     except Exception as e:
         logger.error(f"Error parsing command line: {e}")


### PR DESCRIPTION
### Changes and Why

Adding support to command flag parameter, in this case, parameters that contains no value.
For example:
```
command --stop --vm-id 1234
```

These changes is required to support the new command to manage the AWS EC2 instances.