### PR TITLE
SUSTAINING-1003 new command aws-modify-vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ create-openstack-vm --name=PAYMENTGATEWAY1 --os_name=fedora --flavor=ci.cpu.smal
 ```
 
 
+**/aws-modify-vm --stop --vm-id=<instance_id>**
+Stops a specific AWS EC2 instance by its instance ID. The instance can be restarted later.
+
+**/aws-modify-vm --delete --vm-id=<instance_id>**
+Deletes a specific AWS EC2 instance by its instance ID.
+
+
 **list-openstack-vms <status>**
 Lists OpenStack VMs.
 

--- a/sdk/aws/ec2.py
+++ b/sdk/aws/ec2.py
@@ -314,3 +314,122 @@ class EC2Helper:
                 f"Couldn't delete keypair with name: {key_name}. Error:\n{result}"
             )
             return False
+
+    def stop_instance(self, instance_id: str):
+        """
+        Stop a specific EC2 instance by ID.
+
+        :param instance_id: The ID of the instance to stop
+        :return: Dictionary with operation status and details
+        """
+        try:
+            ec2_client = self.session.client("ec2")
+
+            response = ec2_client.describe_instances(InstanceIds=[instance_id])
+
+            if not response["Reservations"]:
+                return {"success": False, "error": f"Instance {instance_id} not found"}
+
+            instance = response["Reservations"][0]["Instances"][0]
+            current_state = instance["State"]["Name"]
+
+            if current_state == "stopped":
+                return {
+                    "success": False,
+                    "error": f"Instance {instance_id} is already stopped",
+                }
+
+            if current_state not in ["running", "pending"]:
+                return {
+                    "success": False,
+                    "error": f"Instance {instance_id} is in state '{current_state}' and cannot be stopped",
+                }
+
+            response = ec2_client.stop_instances(InstanceIds=[instance_id])
+
+            logger.info(f"Successfully initiated stop for instance {instance_id}")
+
+            return {
+                "success": True,
+                "instance_id": instance_id,
+                "previous_state": current_state,
+                "current_state": response["StoppingInstances"][0]["CurrentState"][
+                    "Name"
+                ],
+            }
+
+        except botocore.exceptions.ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            error_message = e.response["Error"]["Message"]
+            logger.error(
+                f"AWS API error stopping instance {instance_id}: {error_code} - {error_message}"
+            )
+            return {"success": False, "error": f"AWS API error: {error_message}"}
+        except Exception as e:
+            logger.error(f"Unexpected error stopping instance {instance_id}: {str(e)}")
+            return {"success": False, "error": f"Unexpected error: {str(e)}"}
+
+    def terminate_instance(self, instance_id: str):
+        """
+        Terminate (delete) a specific EC2 instance by ID.
+
+        :param instance_id: The ID of the instance to terminate
+        :return: Dictionary with operation status and details
+        """
+        try:
+            ec2_client = self.session.client("ec2")
+
+            response = ec2_client.describe_instances(InstanceIds=[instance_id])
+
+            if not response["Reservations"]:
+                return {"success": False, "error": f"Instance {instance_id} not found"}
+
+            instance = response["Reservations"][0]["Instances"][0]
+            current_state = instance["State"]["Name"]
+
+            if current_state == "terminated":
+                return {
+                    "success": False,
+                    "error": f"Instance {instance_id} is already terminated",
+                }
+
+            if current_state == "terminating":
+                return {
+                    "success": False,
+                    "error": f"Instance {instance_id} is already being terminated",
+                }
+
+            instance_name = ""
+            for tag in instance.get("Tags", []):
+                if tag.get("Key") == "Name":
+                    instance_name = tag.get("Value")
+                    break
+
+            response = ec2_client.terminate_instances(InstanceIds=[instance_id])
+
+            logger.info(
+                f"Successfully initiated termination for instance {instance_id} (name: {instance_name})"
+            )
+
+            return {
+                "success": True,
+                "instance_id": instance_id,
+                "instance_name": instance_name,
+                "previous_state": current_state,
+                "current_state": response["TerminatingInstances"][0]["CurrentState"][
+                    "Name"
+                ],
+            }
+
+        except botocore.exceptions.ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            error_message = e.response["Error"]["Message"]
+            logger.error(
+                f"AWS API error terminating instance {instance_id}: {error_code} - {error_message}"
+            )
+            return {"success": False, "error": f"AWS API error: {error_message}"}
+        except Exception as e:
+            logger.error(
+                f"Unexpected error terminating instance {instance_id}: {str(e)}"
+            )
+            return {"success": False, "error": f"Unexpected error: {str(e)}"}

--- a/sdk/tests/test_aws.py
+++ b/sdk/tests/test_aws.py
@@ -1,4 +1,5 @@
 import unittest.mock as mock
+import botocore.exceptions
 from unittest.mock import Mock
 
 from sdk.aws.ec2 import EC2Helper
@@ -158,3 +159,256 @@ def test_create_instance_unable_create(mock_boto3_session):
 
     assert instance_create["count"] == 0
     assert len(instance_create["instances"]) == 0
+
+
+@mock.patch("boto3.Session")
+def test_stop_instance_success(mock_boto3_session):
+    """Test successful stopping of an EC2 instance."""
+    mock_client = mock.MagicMock()
+
+    mock_client.describe_instances.return_value = {
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": "i-1234567890", "State": {"Name": "running"}}
+                ]
+            }
+        ]
+    }
+
+    mock_client.stop_instances.return_value = {
+        "StoppingInstances": [
+            {
+                "InstanceId": "i-1234567890",
+                "CurrentState": {"Name": "stopping"},
+                "PreviousState": {"Name": "running"},
+            }
+        ]
+    }
+
+    mock_boto3_session.return_value.client.return_value = mock_client
+
+    ec2_helper = EC2Helper(region="us-east-1")
+    result = ec2_helper.stop_instance("i-1234567890")
+
+    assert result["success"] is True
+    assert result["instance_id"] == "i-1234567890"
+    assert result["previous_state"] == "running"
+    assert result["current_state"] == "stopping"
+
+    mock_client.describe_instances.assert_called_once_with(InstanceIds=["i-1234567890"])
+    mock_client.stop_instances.assert_called_once_with(InstanceIds=["i-1234567890"])
+
+
+@mock.patch("boto3.Session")
+def test_stop_instance_already_stopped(mock_boto3_session):
+    """Test stopping an instance that is already stopped."""
+    mock_client = mock.MagicMock()
+
+    mock_client.describe_instances.return_value = {
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": "i-1234567890", "State": {"Name": "stopped"}}
+                ]
+            }
+        ]
+    }
+
+    mock_boto3_session.return_value.client.return_value = mock_client
+
+    ec2_helper = EC2Helper(region="us-east-1")
+    result = ec2_helper.stop_instance("i-1234567890")
+
+    assert result["success"] is False
+    assert "already stopped" in result["error"]
+
+    mock_client.describe_instances.assert_called_once_with(InstanceIds=["i-1234567890"])
+    mock_client.stop_instances.assert_not_called()
+
+
+@mock.patch("boto3.Session")
+def test_stop_instance_not_found(mock_boto3_session):
+    """Test stopping an instance that doesn't exist."""
+    mock_client = mock.MagicMock()
+
+    mock_client.describe_instances.return_value = {"Reservations": []}
+
+    mock_boto3_session.return_value.client.return_value = mock_client
+
+    ec2_helper = EC2Helper(region="us-east-1")
+    result = ec2_helper.stop_instance("i-nonexistent")
+
+    assert result["success"] is False
+    assert "not found" in result["error"]
+
+    mock_client.describe_instances.assert_called_once_with(
+        InstanceIds=["i-nonexistent"]
+    )
+    mock_client.stop_instances.assert_not_called()
+
+
+@mock.patch("boto3.Session")
+def test_stop_instance_invalid_state(mock_boto3_session):
+    """Test stopping an instance in an invalid state (e.g., terminating)."""
+    mock_client = mock.MagicMock()
+
+    mock_client.describe_instances.return_value = {
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": "i-1234567890", "State": {"Name": "terminating"}}
+                ]
+            }
+        ]
+    }
+
+    mock_boto3_session.return_value.client.return_value = mock_client
+
+    ec2_helper = EC2Helper(region="us-east-1")
+    result = ec2_helper.stop_instance("i-1234567890")
+
+    assert result["success"] is False
+    assert "cannot be stopped" in result["error"]
+    assert "terminating" in result["error"]
+
+    mock_client.describe_instances.assert_called_once_with(InstanceIds=["i-1234567890"])
+    mock_client.stop_instances.assert_not_called()
+
+
+@mock.patch("boto3.Session")
+def test_terminate_instance_success(mock_boto3_session):
+    """Test successful termination of an EC2 instance."""
+    mock_client = mock.MagicMock()
+
+    mock_client.describe_instances.return_value = {
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "InstanceId": "i-1234567890",
+                        "State": {"Name": "running"},
+                        "Tags": [
+                            {"Key": "Name", "Value": "test-instance"},
+                            {"Key": "Owner", "Value": "test-user"},
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+
+    mock_client.terminate_instances.return_value = {
+        "TerminatingInstances": [
+            {
+                "InstanceId": "i-1234567890",
+                "CurrentState": {"Name": "shutting-down"},
+                "PreviousState": {"Name": "running"},
+            }
+        ]
+    }
+
+    mock_boto3_session.return_value.client.return_value = mock_client
+
+    ec2_helper = EC2Helper(region="us-east-1")
+    result = ec2_helper.terminate_instance("i-1234567890")
+
+    assert result["success"] is True
+    assert result["instance_id"] == "i-1234567890"
+    assert result["instance_name"] == "test-instance"
+    assert result["previous_state"] == "running"
+    assert result["current_state"] == "shutting-down"
+
+    mock_client.describe_instances.assert_called_once_with(InstanceIds=["i-1234567890"])
+    mock_client.terminate_instances.assert_called_once_with(
+        InstanceIds=["i-1234567890"]
+    )
+
+
+@mock.patch("boto3.Session")
+def test_terminate_instance_already_terminated(mock_boto3_session):
+    """Test terminating an instance that is already terminated."""
+    mock_client = mock.MagicMock()
+
+    mock_client.describe_instances.return_value = {
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": "i-1234567890", "State": {"Name": "terminated"}}
+                ]
+            }
+        ]
+    }
+
+    mock_boto3_session.return_value.client.return_value = mock_client
+
+    ec2_helper = EC2Helper(region="us-east-1")
+    result = ec2_helper.terminate_instance("i-1234567890")
+
+    assert result["success"] is False
+    assert "already terminated" in result["error"]
+
+    mock_client.describe_instances.assert_called_once_with(InstanceIds=["i-1234567890"])
+    mock_client.terminate_instances.assert_not_called()
+
+
+@mock.patch("boto3.Session")
+def test_terminate_instance_terminating(mock_boto3_session):
+    """Test terminating an instance that is already being terminated."""
+    mock_client = mock.MagicMock()
+
+    mock_client.describe_instances.return_value = {
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": "i-1234567890", "State": {"Name": "terminating"}}
+                ]
+            }
+        ]
+    }
+
+    mock_boto3_session.return_value.client.return_value = mock_client
+
+    ec2_helper = EC2Helper(region="us-east-1")
+    result = ec2_helper.terminate_instance("i-1234567890")
+
+    assert result["success"] is False
+    assert "already being terminated" in result["error"]
+
+    mock_client.describe_instances.assert_called_once_with(InstanceIds=["i-1234567890"])
+    mock_client.terminate_instances.assert_not_called()
+
+
+@mock.patch("boto3.Session")
+def test_stop_instance_api_error(mock_boto3_session):
+    """Test handling of AWS API errors when stopping an instance."""
+    mock_client = mock.MagicMock()
+
+    mock_client.describe_instances.return_value = {
+        "Reservations": [
+            {
+                "Instances": [
+                    {"InstanceId": "i-1234567890", "State": {"Name": "running"}}
+                ]
+            }
+        ]
+    }
+
+    error_response = {
+        "Error": {
+            "Code": "UnauthorizedOperation",
+            "Message": "You are not authorized to perform this operation.",
+        }
+    }
+    mock_client.stop_instances.side_effect = botocore.exceptions.ClientError(
+        error_response, "StopInstances"
+    )
+
+    mock_boto3_session.return_value.client.return_value = mock_client
+
+    ec2_helper = EC2Helper(region="us-east-1")
+    result = ec2_helper.stop_instance("i-1234567890")
+
+    assert result["success"] is False
+    assert "AWS API error" in result["error"]
+    assert "not authorized" in result["error"]

--- a/slack_main.py
+++ b/slack_main.py
@@ -14,6 +14,7 @@ from slack_handlers.handlers import (
     handle_create_aws_vm,
     handle_list_aws_vms,
     handle_list_team_links,
+    handle_aws_modify_vm,
 )
 
 logger = logging.getLogger(__name__)
@@ -73,6 +74,9 @@ def mention_handler(body, say):
                 region,
                 app,  # pass `app` so that bot can send DM to users
                 params_dict,
+            ),
+            "aws-modify-vm": lambda: handle_aws_modify_vm(
+                say, region, user, params_dict
             ),
             "list-aws-vms": lambda: handle_list_aws_vms(say, region, user, params_dict),
             "list-team-links": lambda: handle_list_team_links(say, user),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+import os
+
+import pytest
+
+pytest_plugins = [
+    "pytester",
+]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_environment_variables():
+    os.environ["SLACK_BOT_TOKEN"] = "SLACK_BOT_TOKEN"
+    os.environ["SLACK_APP_TOKEN"] = "SLACK_APP_TOKEN"
+    os.environ["AWS_ACCESS_KEY_ID"] = "AWS_ACCESS_KEY_ID"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "AWS_SECRET_ACCESS_KEY"
+    os.environ["AWS_DEFAULT_REGION"] = "AWS_DEFAULT_REGION"
+    os.environ["OS_AUTH_URL"] = "OS_AUTH_URL"
+    os.environ["OS_PROJECT_ID"] = "OS_PROJECT_ID"
+    os.environ["OS_INTERFACE"] = "OS_INTERFACE"
+    os.environ["OS_ID_API_VERSION"] = "OS_ID_API_VERSION"
+    os.environ["OS_REGION_NAME"] = "OS_REGION_NAME"
+    os.environ["OS_APP_CRED_ID"] = "OS_APP_CRED_ID"
+    os.environ["OS_APP_CRED_SECRET"] = "OS_APP_CRED_SECRET"
+    os.environ["OS_AUTH_TYPE"] = "v3applicationcredential"
+    os.environ["ALLOW_ALL_WORKSPACE_USERS"] = "ALLOW_ALL_WORKSPACE_USERS"
+    os.environ["ALLOWED_SLACK_USERS"] = "ALLOWED_SLACK_USERS"

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,176 @@
+import unittest.mock as mock
+from unittest.mock import MagicMock
+
+from slack_handlers.handlers import handle_aws_modify_vm
+
+
+@mock.patch("slack_handlers.handlers.EC2Helper")
+def test_handle_aws_modify_vm_stop_success(mock_ec2_helper):
+    """Test successful stop command."""
+    mock_ec2 = MagicMock()
+    mock_ec2_helper.return_value = mock_ec2
+
+    mock_ec2.stop_instance.return_value = {
+        "success": True,
+        "instance_id": "i-1234567890",
+        "previous_state": "running",
+        "current_state": "stopping",
+    }
+
+    mock_say = MagicMock()
+
+    handle_aws_modify_vm(
+        say=mock_say,
+        region="us-east-1",
+        user="test-user",
+        params_dict={"stop": True, "vm-id": "i-1234567890"},
+    )
+
+    mock_ec2_helper.assert_called_once_with(region="us-east-1")
+
+    mock_ec2.stop_instance.assert_called_once_with("i-1234567890")
+
+    calls = mock_say.call_args_list
+    assert len(calls) == 2
+    assert "Attempting to stop" in calls[0][0][0]
+    assert "Successfully initiated stop" in calls[1][0][0]
+    assert "i-1234567890" in calls[1][0][0]
+
+
+@mock.patch("slack_handlers.handlers.EC2Helper")
+def test_handle_aws_modify_vm_delete_success(mock_ec2_helper):
+    """Test successful delete command."""
+    mock_ec2 = MagicMock()
+    mock_ec2_helper.return_value = mock_ec2
+
+    mock_ec2.terminate_instance.return_value = {
+        "success": True,
+        "instance_id": "i-1234567890",
+        "instance_name": "test-instance",
+        "previous_state": "running",
+        "current_state": "shutting-down",
+    }
+
+    mock_say = MagicMock()
+
+    handle_aws_modify_vm(
+        say=mock_say,
+        region="us-east-1",
+        user="test-user",
+        params_dict={"delete": True, "vm-id": "i-1234567890"},
+    )
+
+    mock_ec2_helper.assert_called_once_with(region="us-east-1")
+
+    mock_ec2.terminate_instance.assert_called_once_with("i-1234567890")
+
+    calls = mock_say.call_args_list
+    assert len(calls) == 2
+    assert "Termination Warning" in calls[0][0][0]
+    assert "Successfully initiated termination" in calls[1][0][0]
+    assert "test-instance" in calls[1][0][0]
+
+
+@mock.patch("slack_handlers.handlers.EC2Helper")
+def test_handle_aws_modify_vm_missing_vm_id(mock_ec2_helper):
+    """Test handle_aws_modify_vm with missing vm-id parameter."""
+    mock_say = MagicMock()
+
+    handle_aws_modify_vm(
+        say=mock_say,
+        region="us-east-1",
+        user="test-user",
+        params_dict={"stop": True},
+    )
+
+    mock_ec2_helper.assert_not_called()
+
+    mock_say.assert_called_once()
+    assert "Missing required parameter" in mock_say.call_args[0][0]
+    assert "--vm-id" in mock_say.call_args[0][0]
+
+
+@mock.patch("slack_handlers.handlers.EC2Helper")
+def test_handle_aws_modify_vm_missing_action(mock_ec2_helper):
+    """Test handle_aws_modify_vm with missing action."""
+    mock_say = MagicMock()
+
+    handle_aws_modify_vm(
+        say=mock_say,
+        region="us-east-1",
+        user="test-user",
+        params_dict={"vm-id": "i-1234567890"},
+    )
+
+    mock_ec2_helper.assert_not_called()
+
+    mock_say.assert_called_once()
+    assert "must specify either" in mock_say.call_args[0][0]
+    assert "--stop" in mock_say.call_args[0][0]
+    assert "--delete" in mock_say.call_args[0][0]
+
+
+@mock.patch("slack_handlers.handlers.EC2Helper")
+def test_handle_aws_modify_vm_both_actions(mock_ec2_helper):
+    """Test handle_aws_modify_vm with both stop and delete actions specified."""
+    mock_say = MagicMock()
+
+    handle_aws_modify_vm(
+        say=mock_say,
+        region="us-east-1",
+        user="test-user",
+        params_dict={"stop": True, "delete": True, "vm-id": "i-1234567890"},
+    )
+
+    mock_ec2_helper.assert_not_called()
+
+    mock_say.assert_called_once()
+    assert "only one action" in mock_say.call_args[0][0]
+    assert "not both" in mock_say.call_args[0][0]
+
+
+@mock.patch("slack_handlers.handlers.EC2Helper")
+def test_handle_aws_modify_vm_stop_failure(mock_ec2_helper):
+    """Test handle_aws_modify_vm when stop operation fails."""
+    mock_ec2 = MagicMock()
+    mock_ec2_helper.return_value = mock_ec2
+
+    mock_ec2.stop_instance.return_value = {
+        "success": False,
+        "error": "Instance i-1234567890 is already stopped",
+    }
+
+    mock_say = MagicMock()
+
+    handle_aws_modify_vm(
+        say=mock_say,
+        region="us-east-1",
+        user="test-user",
+        params_dict={"stop": True, "vm-id": "i-1234567890"},
+    )
+
+    calls = mock_say.call_args_list
+    assert len(calls) == 2
+    assert "Failed to stop instance" in calls[1][0][0]
+
+
+@mock.patch("slack_handlers.handlers.EC2Helper")
+@mock.patch("slack_handlers.handlers.logger")
+def test_handle_aws_modify_vm_exception(mock_logger, mock_ec2_helper):
+    """Test handle_aws_modify_vm when an exception occurs."""
+    mock_ec2_helper.side_effect = Exception("Connection error")
+
+    mock_say = MagicMock()
+
+    handle_aws_modify_vm(
+        say=mock_say,
+        region="us-east-1",
+        user="test-user",
+        params_dict={"stop": True, "vm-id": "i-1234567890"},
+    )
+
+    mock_logger.error.assert_called()
+
+    mock_say.assert_called_once()
+    assert "internal error occurred" in mock_say.call_args[0][0]
+    assert "contact the administrator" in mock_say.call_args[0][0]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,16 @@
+from pytest import Pytester
+
+
+class TestRunner(object):
+    def test_handlers(self, pytester: Pytester) -> None:
+        """Test the slack handlers."""
+        pytester.copy_example("test_handlers.py")
+        result = pytester.runpytest()
+        outcomes = result.parseoutcomes()
+        assert "failed" not in outcomes.keys(), (
+            f"{outcomes['failed']} unit tests failed."
+        )
+        assert "errors" not in outcomes.keys(), (
+            f"{outcomes['errors']} unit tests have errors."
+        )
+        assert "passed" in outcomes.keys(), "No tests passed."


### PR DESCRIPTION
### Changes

Introducing a new command `aws-modify-vm`.
The command can be used to stop or delete a VM on AWS.

Check the examples
```
aws-modify-vm --stop --vm-id=1234       //stop an EC2 instance on AWS
aws-modify-vm --delete --vm-id=1234   //delete (terminate) an EC2 instance on AWS
```