### PR TITLE
Dynaconf treats ALLOW_ALL_WORKSPACE_USERS setting as an int, so the c…

### DIFF
--- a/slack_main.py
+++ b/slack_main.py
@@ -35,7 +35,7 @@ def is_user_allowed(user_id: str) -> bool:
 @app.event("message")
 def mention_handler(body, say):
     user = body.get("event", {}).get("user")
-    if config.ALLOW_ALL_WORKSPACE_USERS != "1":
+    if config.ALLOW_ALL_WORKSPACE_USERS:
         if not is_user_allowed(user):
             say(
                 f"Sorry <@{user}>, you're not authorized to use this bot.Contact ocp-sustaining-admin@redhat.com for assistance."


### PR DESCRIPTION
Dynaconf treats ALLOW_ALL_WORKSPACE_USERS setting as an int, so the code needs to be updated:

When the code is reached:
if config.ALLOW_ALL_WORKSPACE_USERS != "1":
The value is 1:

config.ALLOW_ALL_WORKSPACE_USERS
1
config.ALLOW_ALL_WORKSPACE_USERS == True
True
config.ALLOW_ALL_WORKSPACE_USERS == 1
True

**config.ALLOW_ALL_WORKSPACE_USERS == "1"
False**

it doesn't matter if it's
ALLOW_ALL_WORKSPACE_USERS="1"
it gets converted to an int

This PR fixes this issue