### PR TITLE
allow parameters that are not key/value pairs

### DIFF
--- a/sdk/tests/test_tools.py
+++ b/sdk/tests/test_tools.py
@@ -1,137 +1,173 @@
 from sdk.tools.helpers import (
-    get_dict_of_command_parameters,
+    process_command_parameters,
     get_list_of_values_for_key_in_dict_of_parameters,
 )
 
 
 def test_get_dict_of_command_parameters_when_no_params():
-    params_dict = get_dict_of_command_parameters("list-aws-vms")
+    params_dict, list_params = process_command_parameters("list-aws-vms")
     assert len(params_dict) == 0
+    assert len(list_params) == 0
 
 
 def test_get_dict_of_command_parameters_when_no_key_value_params():
-    params_dict = get_dict_of_command_parameters("list-aws-vms something else")
+    params_dict, list_params = process_command_parameters("list-aws-vms something else")
     assert len(params_dict) == 0
+    assert "something" == list_params[0]
+    assert "else" == list_params[1]
 
 
-def test_get_dict_of_command_parameters_when_good_params_with_equals_separator():
-    params_dict = get_dict_of_command_parameters(
-        "list-aws-vms --type=t3.micro,t2.micro --state=pending,stopped"
+def test_get_dict_of_command_parameters_when_mixture_param_types():
+    params_dict, list_params = process_command_parameters(
+        "list-aws-vms paramA paramB --type=t3.micro,t2.micro --state=pending,stopped spaces spaces2"
     )
     assert "t3.micro,t2.micro" == params_dict.get("type")
-    assert "pending,stopped" == params_dict.get("state")
+    assert "pending,stopped spaces spaces2" == params_dict.get("state")
+    assert "paramA" == list_params[0]
+    assert "paramB" == list_params[1]
+
+
+def test_get_dict_of_command_parameters_when_rota_command():
+    params_dict, list_params = process_command_parameters("rota add 1.2.3")
+    assert len(params_dict) == 0
+    assert "add" == list_params[0]
+    assert "1.2.3" == list_params[1]
 
 
 def test_get_dict_of_command_parameters_when_single_value_params_with_equals_separator():
-    params_dict = get_dict_of_command_parameters(
+    params_dict, list_params = process_command_parameters(
         "list-aws-vms --type=t3.micro --state=pending"
     )
     assert "t3.micro" == params_dict.get("type")
     assert "pending" == params_dict.get("state")
+    assert len(list_params) == 0
 
 
 def test_get_dict_of_command_parameters_when_single_value_params_with_no_equals_separator():
-    params_dict = get_dict_of_command_parameters(
+    params_dict, list_params = process_command_parameters(
         "list-aws-vms --type  t3.micro --state  pending"
     )
     assert "t3.micro" == params_dict.get("type")
     assert "pending" == params_dict.get("state")
+    assert len(list_params) == 0
 
 
 def test_get_dict_of_command_parameters_when_no_equals_separator():
-    params_dict = get_dict_of_command_parameters(
+    params_dict, list_params = process_command_parameters(
         "list-aws-vms --type  t3.micro, t2.micro, t1.micro --state  pending"
     )
     assert params_dict.get("type") == "t3.micro,t2.micro,t1.micro"
     assert params_dict.get("state") == "pending"
+    assert len(list_params) == 0
 
 
 def test_get_dict_of_command_parameters_when_good_params_with_no_equals_separator():
-    params_dict = get_dict_of_command_parameters(
-        "list-aws-vms --type t3.micro,t2.micro --state pending,stopped"
+    params_dict, list_params = process_command_parameters(
+        "list-aws-vms paramA paramB --type t3.micro,t2.micro --state pending,stopped"
     )
     assert "t3.micro,t2.micro" == params_dict.get("type")
     assert "pending,stopped" == params_dict.get("state")
+    assert "paramA" == list_params[0]
+    assert "paramB" == list_params[1]
 
 
 def test_get_dict_of_command_parameters_when_mixture_good_params():
-    params_dict = get_dict_of_command_parameters(
-        "list-aws-vms --type t3.micro,t2.micro --state=pending,stopped"
+    params_dict, list_params = process_command_parameters(
+        "list-aws-vms paramA paramB --type t3.micro,t2.micro --state=pending,stopped"
     )
     assert "t3.micro,t2.micro" == params_dict.get("type")
     assert "pending,stopped" == params_dict.get("state")
+    assert "paramA" == list_params[0]
+    assert "paramB" == list_params[1]
 
 
 def test_get_dict_of_command_parameters_when_value_has_spaces():
-    params_dict = get_dict_of_command_parameters(
-        'list-aws-vms --desc "some value with space" --state pending'
+    params_dict, list_params = process_command_parameters(
+        "list-aws-vms paramA paramB --desc some value with space --state pending"
     )
     assert "some value with space" == params_dict.get("desc")
     assert "pending" == params_dict.get("state")
+    assert "paramA" == list_params[0]
+    assert "paramB" == list_params[1]
 
 
 def test_get_dict_when_command_has_extra_spaces():
-    params_dict = get_dict_of_command_parameters(
-        "create-aws-vm   --os_name=linux    --instance_type=t2.micro  --key_pair=my-key"
+    params_dict, list_params = process_command_parameters(
+        "create-aws-vm paramA paramB  --os_name=linux    --instance_type=t2.micro  --key_pair=my-key"
     )
     assert "linux" == params_dict.get("os_name")
     assert "t2.micro" == params_dict.get("instance_type")
     assert "my-key" == params_dict.get("key_pair")
+    assert "paramA" == list_params[0]
+    assert "paramB" == list_params[1]
 
 
 def test_get_dict_when_spaces_between_params():
-    params_dict = get_dict_of_command_parameters(
-        "create-aws-vm --state=pending, stopped , running"
+    params_dict, list_params = process_command_parameters(
+        "create-aws-vm   paramA   paramB  --state=pending, stopped , running"
     )
     assert "pending,stopped,running" == params_dict.get("state")
+    assert "paramA" == list_params[0]
+    assert "paramB" == list_params[1]
 
 
 def test_get_dict_when_trailing_commas_between_params():
-    params_dict = get_dict_of_command_parameters(
+    params_dict, list_params = process_command_parameters(
         "create-aws-vm --state=pending, stopped, "
     )
     assert "pending,stopped" == params_dict.get("state")
-    params_dict = get_dict_of_command_parameters(
-        "create-aws-vm --state=pending,,, stopped,,,, "
+    params_dict, list_params = process_command_parameters(
+        "create-aws-vm paramA paramB --state=pending,,, stopped,,,, "
     )
     assert "pending,stopped" == params_dict.get("state")
+    assert "paramA" == list_params[0]
+    assert "paramB" == list_params[1]
 
 
 def test_get_dict_when_multi_words_in_command_line():
-    params_dict = get_dict_of_command_parameters(
-        "command --vm-id=i-123456 --multi=these are values --state=pending, stopped"
+    params_dict, list_params = process_command_parameters(
+        "command paramA paramB --vm-id=i-123456 --multi=these are values --state=pending, stopped"
     )
     assert params_dict.get("state") == "pending,stopped"
     assert params_dict.get("vm-id") == "i-123456"
     assert params_dict.get("multi") == "these are values"
+    assert "paramA" == list_params[0]
+    assert "paramB" == list_params[1]
 
 
 def test_get_dict_with_flag_parameters():
-    params_dict = get_dict_of_command_parameters(
-        "aws-modify-vm --stop --vm-id=i-123456"
+    params_dict, list_params = process_command_parameters(
+        "aws-modify-vm paramA paramB --stop --vm-id=i-123456"
     )
     assert params_dict.get("stop") is True
     assert params_dict.get("vm-id") == "i-123456"
+    assert "paramA" == list_params[0]
+    assert "paramB" == list_params[1]
 
 
 def test_get_dict_with_multiple_flag_parameters():
-    params_dict = get_dict_of_command_parameters("command --flag1 --flag2 --value=test")
+    params_dict, list_params = process_command_parameters(
+        "command paramA --flag1 --flag2 --value=test"
+    )
     assert params_dict.get("flag1") is True
     assert params_dict.get("flag2") is True
     assert params_dict.get("value") == "test"
+    assert "paramA" == list_params[0]
 
 
 def test_get_dict_with_only_flag_parameters():
-    params_dict = get_dict_of_command_parameters("command --stop --delete")
+    params_dict, list_params = process_command_parameters("command --stop --delete")
     assert params_dict.get("stop") is True
     assert params_dict.get("delete") is True
     assert len(params_dict) == 2
+    assert len(list_params) == 0
 
 
 def test_get_list_of_values_for_key_in_dict_of_parameters_when_absent_key():
-    params_dict = get_dict_of_command_parameters("command --stop --delete")
+    params_dict, list_params = process_command_parameters("command --stop --delete")
     result = params_dict.get("absent_key")
     assert result is None
+    assert len(list_params) == 0
 
 
 def test_get_list_of_values_for_key_in_dict_of_parameters_when_present_in_dict_params():

--- a/sdk/tests/test_tools.py
+++ b/sdk/tests/test_tools.py
@@ -1,173 +1,188 @@
 from sdk.tools.helpers import (
-    process_command_parameters,
+    get_sub_commands_and_params,
     get_list_of_values_for_key_in_dict_of_parameters,
 )
 
 
 def test_get_dict_of_command_parameters_when_no_params():
-    params_dict, list_params = process_command_parameters("list-aws-vms")
+    params_dict, list_params = get_sub_commands_and_params("list-aws-vms")
     assert len(params_dict) == 0
-    assert len(list_params) == 0
+    assert len(list_params) == 1
 
 
 def test_get_dict_of_command_parameters_when_no_key_value_params():
-    params_dict, list_params = process_command_parameters("list-aws-vms something else")
+    params_dict, list_params = get_sub_commands_and_params(
+        "list-aws-vms something else"
+    )
     assert len(params_dict) == 0
-    assert "something" == list_params[0]
-    assert "else" == list_params[1]
+    assert "list-aws-vms" == list_params[0]
+    assert "something" == list_params[1]
+    assert "else" == list_params[2]
 
 
 def test_get_dict_of_command_parameters_when_mixture_param_types():
-    params_dict, list_params = process_command_parameters(
+    params_dict, list_params = get_sub_commands_and_params(
         "list-aws-vms paramA paramB --type=t3.micro,t2.micro --state=pending,stopped spaces spaces2"
     )
     assert "t3.micro,t2.micro" == params_dict.get("type")
     assert "pending,stopped spaces spaces2" == params_dict.get("state")
-    assert "paramA" == list_params[0]
-    assert "paramB" == list_params[1]
+    assert "list-aws-vms" == list_params[0]
+    assert "paramA" == list_params[1]
+    assert "paramB" == list_params[2]
 
 
 def test_get_dict_of_command_parameters_when_rota_command():
-    params_dict, list_params = process_command_parameters("rota add 1.2.3")
+    params_dict, list_params = get_sub_commands_and_params("rota add 1.2.3")
     assert len(params_dict) == 0
-    assert "add" == list_params[0]
-    assert "1.2.3" == list_params[1]
+    assert "rota" == list_params[0]
+    assert "add" == list_params[1]
+    assert "1.2.3" == list_params[2]
 
 
 def test_get_dict_of_command_parameters_when_single_value_params_with_equals_separator():
-    params_dict, list_params = process_command_parameters(
+    params_dict, list_params = get_sub_commands_and_params(
         "list-aws-vms --type=t3.micro --state=pending"
     )
     assert "t3.micro" == params_dict.get("type")
     assert "pending" == params_dict.get("state")
-    assert len(list_params) == 0
+    assert "list-aws-vms" == list_params[0]
 
 
 def test_get_dict_of_command_parameters_when_single_value_params_with_no_equals_separator():
-    params_dict, list_params = process_command_parameters(
+    params_dict, list_params = get_sub_commands_and_params(
         "list-aws-vms --type  t3.micro --state  pending"
     )
     assert "t3.micro" == params_dict.get("type")
     assert "pending" == params_dict.get("state")
-    assert len(list_params) == 0
+    assert len(list_params) == 1
+    assert "list-aws-vms" == list_params[0]
 
 
 def test_get_dict_of_command_parameters_when_no_equals_separator():
-    params_dict, list_params = process_command_parameters(
+    params_dict, list_params = get_sub_commands_and_params(
         "list-aws-vms --type  t3.micro, t2.micro, t1.micro --state  pending"
     )
     assert params_dict.get("type") == "t3.micro,t2.micro,t1.micro"
     assert params_dict.get("state") == "pending"
-    assert len(list_params) == 0
+    assert "list-aws-vms" == list_params[0]
 
 
 def test_get_dict_of_command_parameters_when_good_params_with_no_equals_separator():
-    params_dict, list_params = process_command_parameters(
+    params_dict, list_params = get_sub_commands_and_params(
         "list-aws-vms paramA paramB --type t3.micro,t2.micro --state pending,stopped"
     )
     assert "t3.micro,t2.micro" == params_dict.get("type")
     assert "pending,stopped" == params_dict.get("state")
-    assert "paramA" == list_params[0]
-    assert "paramB" == list_params[1]
+    assert "list-aws-vms" == list_params[0]
+    assert "paramA" == list_params[1]
+    assert "paramB" == list_params[2]
 
 
 def test_get_dict_of_command_parameters_when_mixture_good_params():
-    params_dict, list_params = process_command_parameters(
+    params_dict, list_params = get_sub_commands_and_params(
         "list-aws-vms paramA paramB --type t3.micro,t2.micro --state=pending,stopped"
     )
     assert "t3.micro,t2.micro" == params_dict.get("type")
     assert "pending,stopped" == params_dict.get("state")
-    assert "paramA" == list_params[0]
-    assert "paramB" == list_params[1]
+    assert "list-aws-vms" == list_params[0]
+    assert "paramA" == list_params[1]
+    assert "paramB" == list_params[2]
 
 
 def test_get_dict_of_command_parameters_when_value_has_spaces():
-    params_dict, list_params = process_command_parameters(
+    params_dict, list_params = get_sub_commands_and_params(
         "list-aws-vms paramA paramB --desc some value with space --state pending"
     )
     assert "some value with space" == params_dict.get("desc")
     assert "pending" == params_dict.get("state")
-    assert "paramA" == list_params[0]
-    assert "paramB" == list_params[1]
+    assert "list-aws-vms" == list_params[0]
+    assert "paramA" == list_params[1]
+    assert "paramB" == list_params[2]
 
 
 def test_get_dict_when_command_has_extra_spaces():
-    params_dict, list_params = process_command_parameters(
+    params_dict, list_params = get_sub_commands_and_params(
         "create-aws-vm paramA paramB  --os_name=linux    --instance_type=t2.micro  --key_pair=my-key"
     )
     assert "linux" == params_dict.get("os_name")
     assert "t2.micro" == params_dict.get("instance_type")
     assert "my-key" == params_dict.get("key_pair")
-    assert "paramA" == list_params[0]
-    assert "paramB" == list_params[1]
+    assert "create-aws-vm" == list_params[0]
+    assert "paramA" == list_params[1]
+    assert "paramB" == list_params[2]
 
 
 def test_get_dict_when_spaces_between_params():
-    params_dict, list_params = process_command_parameters(
+    params_dict, list_params = get_sub_commands_and_params(
         "create-aws-vm   paramA   paramB  --state=pending, stopped , running"
     )
     assert "pending,stopped,running" == params_dict.get("state")
-    assert "paramA" == list_params[0]
-    assert "paramB" == list_params[1]
+    assert "create-aws-vm" == list_params[0]
+    assert "paramA" == list_params[1]
+    assert "paramB" == list_params[2]
 
 
 def test_get_dict_when_trailing_commas_between_params():
-    params_dict, list_params = process_command_parameters(
+    params_dict, list_params = get_sub_commands_and_params(
         "create-aws-vm --state=pending, stopped, "
     )
     assert "pending,stopped" == params_dict.get("state")
-    params_dict, list_params = process_command_parameters(
+    params_dict, list_params = get_sub_commands_and_params(
         "create-aws-vm paramA paramB --state=pending,,, stopped,,,, "
     )
     assert "pending,stopped" == params_dict.get("state")
-    assert "paramA" == list_params[0]
-    assert "paramB" == list_params[1]
+    assert "create-aws-vm" == list_params[0]
+    assert "paramA" == list_params[1]
+    assert "paramB" == list_params[2]
 
 
 def test_get_dict_when_multi_words_in_command_line():
-    params_dict, list_params = process_command_parameters(
+    params_dict, list_params = get_sub_commands_and_params(
         "command paramA paramB --vm-id=i-123456 --multi=these are values --state=pending, stopped"
     )
     assert params_dict.get("state") == "pending,stopped"
     assert params_dict.get("vm-id") == "i-123456"
     assert params_dict.get("multi") == "these are values"
-    assert "paramA" == list_params[0]
-    assert "paramB" == list_params[1]
+    assert "command" == list_params[0]
+    assert "paramA" == list_params[1]
+    assert "paramB" == list_params[2]
 
 
 def test_get_dict_with_flag_parameters():
-    params_dict, list_params = process_command_parameters(
+    params_dict, list_params = get_sub_commands_and_params(
         "aws-modify-vm paramA paramB --stop --vm-id=i-123456"
     )
     assert params_dict.get("stop") is True
     assert params_dict.get("vm-id") == "i-123456"
-    assert "paramA" == list_params[0]
-    assert "paramB" == list_params[1]
+    assert "aws-modify-vm" == list_params[0]
+    assert "paramA" == list_params[1]
+    assert "paramB" == list_params[2]
 
 
 def test_get_dict_with_multiple_flag_parameters():
-    params_dict, list_params = process_command_parameters(
+    params_dict, list_params = get_sub_commands_and_params(
         "command paramA --flag1 --flag2 --value=test"
     )
     assert params_dict.get("flag1") is True
     assert params_dict.get("flag2") is True
     assert params_dict.get("value") == "test"
-    assert "paramA" == list_params[0]
+    assert "command" == list_params[0]
+    assert "paramA" == list_params[1]
 
 
 def test_get_dict_with_only_flag_parameters():
-    params_dict, list_params = process_command_parameters("command --stop --delete")
+    params_dict, list_params = get_sub_commands_and_params("command --stop --delete")
     assert params_dict.get("stop") is True
     assert params_dict.get("delete") is True
     assert len(params_dict) == 2
-    assert len(list_params) == 0
+    assert len(list_params) == 1
 
 
 def test_get_list_of_values_for_key_in_dict_of_parameters_when_absent_key():
-    params_dict, list_params = process_command_parameters("command --stop --delete")
+    params_dict, list_params = get_sub_commands_and_params("command --stop --delete")
     result = params_dict.get("absent_key")
     assert result is None
-    assert len(list_params) == 0
+    assert len(list_params) == 1
 
 
 def test_get_list_of_values_for_key_in_dict_of_parameters_when_present_in_dict_params():

--- a/sdk/tools/helpers.py
+++ b/sdk/tools/helpers.py
@@ -4,7 +4,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def process_command_parameters(command_line: str) -> dict:
+def get_sub_commands_and_params(command_line: str) -> dict:
     """
     Parse command line arguments into a dictionary of parameters and their values and/or a list of parameters
 
@@ -39,33 +39,33 @@ def process_command_parameters(command_line: str) -> dict:
         arg1 arg2
 
     Examples:
-        >>> process_command_parameters("list-aws-vms --type=t3.micro,t2.micro --state=pending,stopped --stop")
+        >>> get_sub_commands_and_params("list-aws-vms --type=t3.micro,t2.micro --state=pending,stopped --stop")
         {'type': 't3.micro,t2.micro', 'state': 'pending,stopped', 'stop': True}
-        []
+        ["list-aws-vms"]
 
-        >>> process_command_parameters("command --region us-east-1 --verbose")
+        >>> get_sub_commands_and_params("command --region us-east-1 --verbose")
         {'region': 'us-east-1', 'verbose': True}
-        []
+        ["command"]
 
-        >>> process_command_parameters("command --name 'my server' --count 5")
+        >>> get_sub_commands_and_params("command --name 'my server' --count 5")
         {'name': 'my server', 'count': '5'}
-        []
+        ["command"]
 
-        >>> process_command_parameters("command --list item1, item2 , item3")
+        >>> get_sub_commands_and_params("command --list item1, item2 , item3")
         {'list': 'item1,item2,item3'}
-        []
+        ["command"]
 
-        >>> process_command_parameters("")
+        >>> get_sub_commands_and_params("")
         {}
         []
 
-        >>> process_command_parameters("command-with-no-params")
+        >>> get_sub_commands_and_params("command-with-no-params")
         {}
-        []
+        ["command-with-no-params"]
 
-        >>> process_command_parameters("list-aws-vms param1 param2 --type=t3.micro,t2.micro --state=pending,stopped --stop")
+        >>> get_sub_commands_and_params("list-aws-vms param1 param2 --type=t3.micro,t2.micro --state=pending,stopped --stop")
         {'type': 't3.micro,t2.micro', 'state': 'pending,stopped', 'stop': True}
-        ['param1','param2']
+        ['list-aws-vms', 'param1','param2']
 
     Notes:
         - Parameter names have leading dashes (-/--) stripped from keys
@@ -161,9 +161,6 @@ def process_command_parameters(command_line: str) -> dict:
     except Exception as e:
         logger.error(f"Error parsing command line '{command_line}': {e}")
 
-    if len(plain_params) > 0:
-        # skip over the command value e.g. like aws-list-vms
-        plain_params = plain_params[1:]
     return parsed_key_value_params, plain_params
 
 

--- a/slack_main.py
+++ b/slack_main.py
@@ -1,7 +1,7 @@
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 from config import config
-from sdk.tools.helpers import process_command_parameters
+from sdk.tools.helpers import get_sub_commands_and_params
 from sdk.tools.help_system import handle_help_command, check_help_flag
 import logging
 import json
@@ -62,7 +62,7 @@ def mention_handler(body, say):
             command_line = " ".join(cmd_strings)
 
         # Extract parameters using the utility function
-        params_dict, list_params = process_command_parameters(command_line)
+        params_dict, list_params = get_sub_commands_and_params(command_line)
 
         # Check if this is a help request for a specific command
         if check_help_flag(params_dict):

--- a/slack_main.py
+++ b/slack_main.py
@@ -1,7 +1,7 @@
 from slack_bolt import App
 from slack_bolt.adapter.socket_mode import SocketModeHandler
 from config import config
-from sdk.tools.helpers import get_dict_of_command_parameters
+from sdk.tools.helpers import process_command_parameters
 from sdk.tools.help_system import handle_help_command, check_help_flag
 import logging
 import json
@@ -37,12 +37,15 @@ def is_user_allowed(user_id: str) -> bool:
 @app.event("message")
 def mention_handler(body, say):
     user = body.get("event", {}).get("user")
+
+    # Authorization check
     if config.ALLOW_ALL_WORKSPACE_USERS:
         if not is_user_allowed(user):
             say(
                 f"Sorry <@{user}>, you're not authorized to use this bot.Contact ocp-sustaining-admin@redhat.com for assistance."
             )
             return
+
     command_line = body.get("event", {}).get("text", "").strip()
     region = config.AWS_DEFAULT_REGION
 
@@ -59,7 +62,7 @@ def mention_handler(body, say):
             command_line = " ".join(cmd_strings)
 
         # Extract parameters using the utility function
-        params_dict = get_dict_of_command_parameters(command_line)
+        params_dict, list_params = process_command_parameters(command_line)
 
         # Check if this is a help request for a specific command
         if check_help_flag(params_dict):
@@ -79,6 +82,7 @@ def mention_handler(body, say):
                 handle_help_command(say, user)
             return
 
+        # Command routing
         commands = {
             "create-openstack-vm": lambda: handle_create_openstack_vm(
                 say, user, app, params_dict


### PR DESCRIPTION
allow parameters that are not key/value pairs at the start of the subcommands
For example:
rota add 1.2.3
rota add 1.2.3 --mykey=myvalue --mykey2=myvalue2