### PR TITLE
Normalizing the commands pattern

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -81,3 +81,7 @@ jobs:
         if: (contains(env.CHANGED, 'tests/') && !contains(env.CHANGED, 'sdk/')) || contains(env.CHANGED, 'slack_handlers/')
         run: |
           python -m pytest tests/test_runner.py::TestRunner::test_handlers
+
+      - name: Test Slack Commands
+        run: |
+          python -m pytest tests/test_runner.py::TestRunner::test_slack_commands

--- a/README.md
+++ b/README.md
@@ -81,25 +81,25 @@ python slack_main.py
 Creates an AWS OpenShift cluster using the provided cluster_name.
 
 
-**create-aws-vm**
+**aws vm create**
 Creates an AWS EC2 instance.
 
 Sample usage:
 ```
-create-aws-vm --os_name=linux --instance_type=t2.micro --key_pair=new
-create-aws-vm --os_name=linux --instance_type=t2.micro --key_pair=existing
+aws vm create --os_name=linux --instance_type=t2.micro --key_pair=new
+aws vm create --os_name=linux --instance_type=t2.micro --key_pair=existing
 ```
 
-**list-aws-vms**
+**aws vm list**
 Lists AWS EC2 instances
 
 Sample usage:
 ```
 
-list-aws-vms --state=pending,running,shutting-down,terminated,stopping,stopped
-list-aws-vms --type=t3.micro,t2.micro
-list-aws-vms --type=t3.micro,t2.micro --state=pending,stopped
-list-aws-vms --instance-ids=i-123456,i-987654
+aws vm list --state=pending,running,shutting-down,terminated,stopping,stopped
+aws vm list --type=t3.micro,t2.micro
+aws vm list --type=t3.micro,t2.micro --state=pending,stopped
+aws vm list --instance-ids=i-123456,i-987654
 
 ```
 Note 1:
@@ -108,29 +108,29 @@ See [https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/
 Search for t2.micro
 
 
-**create-openstack-vm <name> <image> <flavor> <network>**
+**openstack vm create <name> <image> <flavor> <network>**
 Creates an OpenStack VM with the specified name, os type, flavor, network and key name.
 
 Sample usage:
 ```
-create-openstack-vm --name=PAYMENTGATEWAY1 --os_name=fedora --flavor=ci.cpu.small --network=provider_net_ocp_dev --key_name=sustaining-bot-key
+openstack vm create --name=PAYMENTGATEWAY1 --os_name=fedora --flavor=ci.cpu.small --network=provider_net_ocp_dev --key_name=sustaining-bot-key
 ```
 
 
-**/aws-modify-vm --stop --vm-id=<instance_id>**
+**/aws vm modify --stop --vm-id=<instance_id>**
 Stops a specific AWS EC2 instance by its instance ID. The instance can be restarted later.
 
-**/aws-modify-vm --delete --vm-id=<instance_id>**
+**/aws vm modify --delete --vm-id=<instance_id>**
 Deletes a specific AWS EC2 instance by its instance ID.
 
 
-**list-openstack-vms <status>**
+**openstack vm list <status>**
 Lists OpenStack VMs.
 
 Sample usage:
 ```
-list-openstack-vms -status=ACTIVE
-list-openstack-vms -status=ERROR
+openstack vm list -status=ACTIVE
+openstack vm list -status=ERROR
 ```
 
 **hello**

--- a/sdk/tests/conftest.py
+++ b/sdk/tests/conftest.py
@@ -36,3 +36,10 @@ def setup_environment_variables():
     os.environ["VAULT_MOUNT_POINT_FOR_DYNACONF"] = "VAULT_MOUNT_POINT_FOR_DYNACONF"
     os.environ["VAULT_PATH_FOR_DYNACONF"] = "VAULT_PATH_FOR_DYNACONF"
     os.environ["VAULT_KV_VERSION_FOR_DYNACONF"] = "VAULT_KV_VERSION_FOR_DYNACONF"
+
+
+@pytest.fixture(autouse=True)
+def populate_command_registry():
+    """Ensure COMMAND_REGISTRY is populated for tests."""
+    import slack_handlers.handlers  # noqa: F401
+    from sdk.tools.help_system import COMMAND_REGISTRY  # noqa: F401

--- a/sdk/tests/test_tools.py
+++ b/sdk/tests/test_tools.py
@@ -1,188 +1,181 @@
 from sdk.tools.helpers import (
-    get_sub_commands_and_params,
+    get_named_and_positional_params,
     get_list_of_values_for_key_in_dict_of_parameters,
 )
 
 
-def test_get_dict_of_command_parameters_when_no_params():
-    params_dict, list_params = get_sub_commands_and_params("list-aws-vms")
-    assert len(params_dict) == 0
-    assert len(list_params) == 1
+def test_get_named_and_positional_params_when_no_params():
+    named_params, positional_params = get_named_and_positional_params("aws vm list")
+    assert len(named_params) == 0
+    assert len(positional_params) == 0
 
 
-def test_get_dict_of_command_parameters_when_no_key_value_params():
-    params_dict, list_params = get_sub_commands_and_params(
-        "list-aws-vms something else"
+def test_get_named_and_positional_params_when_no_key_value_params():
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm list something else"
     )
-    assert len(params_dict) == 0
-    assert "list-aws-vms" == list_params[0]
-    assert "something" == list_params[1]
-    assert "else" == list_params[2]
+    assert len(named_params) == 0
+    assert "something" == positional_params[0]
+    assert "else" == positional_params[1]
 
 
-def test_get_dict_of_command_parameters_when_mixture_param_types():
-    params_dict, list_params = get_sub_commands_and_params(
-        "list-aws-vms paramA paramB --type=t3.micro,t2.micro --state=pending,stopped spaces spaces2"
+def test_get_named_and_positional_params_when_mixture_param_types():
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm list paramA paramB --type=t3.micro,t2.micro --state=pending,stopped spaces spaces2"
     )
-    assert "t3.micro,t2.micro" == params_dict.get("type")
-    assert "pending,stopped spaces spaces2" == params_dict.get("state")
-    assert "list-aws-vms" == list_params[0]
-    assert "paramA" == list_params[1]
-    assert "paramB" == list_params[2]
+    assert "t3.micro,t2.micro" == named_params.get("type")
+    assert "pending,stopped spaces spaces2" == named_params.get("state")
+    assert "paramA" == positional_params[0]
+    assert "paramB" == positional_params[1]
 
 
-def test_get_dict_of_command_parameters_when_rota_command():
-    params_dict, list_params = get_sub_commands_and_params("rota add 1.2.3")
-    assert len(params_dict) == 0
-    assert "rota" == list_params[0]
-    assert "add" == list_params[1]
-    assert "1.2.3" == list_params[2]
-
-
-def test_get_dict_of_command_parameters_when_single_value_params_with_equals_separator():
-    params_dict, list_params = get_sub_commands_and_params(
-        "list-aws-vms --type=t3.micro --state=pending"
+def test_get_named_and_positional_params_when_using_positional_params():
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm create linux 1.2.3"
     )
-    assert "t3.micro" == params_dict.get("type")
-    assert "pending" == params_dict.get("state")
-    assert "list-aws-vms" == list_params[0]
+    assert len(named_params) == 0
+    assert "linux" == positional_params[0]
+    assert "1.2.3" == positional_params[1]
 
 
-def test_get_dict_of_command_parameters_when_single_value_params_with_no_equals_separator():
-    params_dict, list_params = get_sub_commands_and_params(
-        "list-aws-vms --type  t3.micro --state  pending"
+def test_get_named_and_positional_params_when_single_value_params_with_equals_separator():
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm list --type=t3.micro --state=pending"
     )
-    assert "t3.micro" == params_dict.get("type")
-    assert "pending" == params_dict.get("state")
-    assert len(list_params) == 1
-    assert "list-aws-vms" == list_params[0]
+    assert "t3.micro" == named_params.get("type")
+    assert "pending" == named_params.get("state")
+    assert not positional_params
 
 
-def test_get_dict_of_command_parameters_when_no_equals_separator():
-    params_dict, list_params = get_sub_commands_and_params(
-        "list-aws-vms --type  t3.micro, t2.micro, t1.micro --state  pending"
+def test_get_named_and_positional_params_when_single_value_params_with_no_equals_separator():
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm list --type  t3.micro --state  pending"
     )
-    assert params_dict.get("type") == "t3.micro,t2.micro,t1.micro"
-    assert params_dict.get("state") == "pending"
-    assert "list-aws-vms" == list_params[0]
+    assert "t3.micro" == named_params.get("type")
+    assert "pending" == named_params.get("state")
+    assert len(positional_params) == 0
 
 
-def test_get_dict_of_command_parameters_when_good_params_with_no_equals_separator():
-    params_dict, list_params = get_sub_commands_and_params(
-        "list-aws-vms paramA paramB --type t3.micro,t2.micro --state pending,stopped"
+def test_get_named_and_positional_params_when_no_equals_separator():
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm list --type  t3.micro, t2.micro, t1.micro --state  pending"
     )
-    assert "t3.micro,t2.micro" == params_dict.get("type")
-    assert "pending,stopped" == params_dict.get("state")
-    assert "list-aws-vms" == list_params[0]
-    assert "paramA" == list_params[1]
-    assert "paramB" == list_params[2]
+    assert named_params.get("type") == "t3.micro,t2.micro,t1.micro"
+    assert named_params.get("state") == "pending"
+    assert not positional_params
 
 
-def test_get_dict_of_command_parameters_when_mixture_good_params():
-    params_dict, list_params = get_sub_commands_and_params(
-        "list-aws-vms paramA paramB --type t3.micro,t2.micro --state=pending,stopped"
+def test_get_named_and_positional_params_when_good_params_with_no_equals_separator():
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm list paramA paramB --type t3.micro,t2.micro --state pending,stopped"
     )
-    assert "t3.micro,t2.micro" == params_dict.get("type")
-    assert "pending,stopped" == params_dict.get("state")
-    assert "list-aws-vms" == list_params[0]
-    assert "paramA" == list_params[1]
-    assert "paramB" == list_params[2]
+    assert "t3.micro,t2.micro" == named_params.get("type")
+    assert "pending,stopped" == named_params.get("state")
+    assert "paramA" == positional_params[0]
+    assert "paramB" == positional_params[1]
 
 
-def test_get_dict_of_command_parameters_when_value_has_spaces():
-    params_dict, list_params = get_sub_commands_and_params(
-        "list-aws-vms paramA paramB --desc some value with space --state pending"
+def test_get_named_and_positional_params_when_mixture_good_params():
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm list paramA paramB --type t3.micro,t2.micro --state=pending,stopped"
     )
-    assert "some value with space" == params_dict.get("desc")
-    assert "pending" == params_dict.get("state")
-    assert "list-aws-vms" == list_params[0]
-    assert "paramA" == list_params[1]
-    assert "paramB" == list_params[2]
+    assert "t3.micro,t2.micro" == named_params.get("type")
+    assert "pending,stopped" == named_params.get("state")
+    assert "paramA" == positional_params[0]
+    assert "paramB" == positional_params[1]
+
+
+def test_get_named_and_positional_params_when_value_has_spaces():
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm list paramA paramB --desc some value with space --state pending"
+    )
+    assert "some value with space" == named_params.get("desc")
+    assert "pending" == named_params.get("state")
+    assert "paramA" == positional_params[0]
+    assert "paramB" == positional_params[1]
 
 
 def test_get_dict_when_command_has_extra_spaces():
-    params_dict, list_params = get_sub_commands_and_params(
-        "create-aws-vm paramA paramB  --os_name=linux    --instance_type=t2.micro  --key_pair=my-key"
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm create paramA paramB  --os_name=linux    --instance_type=t2.micro  --key_pair=my-key"
     )
-    assert "linux" == params_dict.get("os_name")
-    assert "t2.micro" == params_dict.get("instance_type")
-    assert "my-key" == params_dict.get("key_pair")
-    assert "create-aws-vm" == list_params[0]
-    assert "paramA" == list_params[1]
-    assert "paramB" == list_params[2]
+    assert "linux" == named_params.get("os_name")
+    assert "t2.micro" == named_params.get("instance_type")
+    assert "my-key" == named_params.get("key_pair")
+    assert "paramA" == positional_params[0]
+    assert "paramB" == positional_params[1]
 
 
 def test_get_dict_when_spaces_between_params():
-    params_dict, list_params = get_sub_commands_and_params(
-        "create-aws-vm   paramA   paramB  --state=pending, stopped , running"
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm create   paramA   paramB  --state=pending, stopped , running"
     )
-    assert "pending,stopped,running" == params_dict.get("state")
-    assert "create-aws-vm" == list_params[0]
-    assert "paramA" == list_params[1]
-    assert "paramB" == list_params[2]
+    assert "pending,stopped,running" == named_params.get("state")
+    assert "paramA" == positional_params[0]
+    assert "paramB" == positional_params[1]
 
 
 def test_get_dict_when_trailing_commas_between_params():
-    params_dict, list_params = get_sub_commands_and_params(
-        "create-aws-vm --state=pending, stopped, "
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm create --state=pending, stopped, "
     )
-    assert "pending,stopped" == params_dict.get("state")
-    params_dict, list_params = get_sub_commands_and_params(
-        "create-aws-vm paramA paramB --state=pending,,, stopped,,,, "
+    assert "pending,stopped" == named_params.get("state")
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm create paramA paramB --state=pending,,, stopped,,,, "
     )
-    assert "pending,stopped" == params_dict.get("state")
-    assert "create-aws-vm" == list_params[0]
-    assert "paramA" == list_params[1]
-    assert "paramB" == list_params[2]
+    assert "pending,stopped" == named_params.get("state")
+    assert "paramA" == positional_params[0]
+    assert "paramB" == positional_params[1]
 
 
 def test_get_dict_when_multi_words_in_command_line():
-    params_dict, list_params = get_sub_commands_and_params(
-        "command paramA paramB --vm-id=i-123456 --multi=these are values --state=pending, stopped"
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm create paramA paramB --vm-id=i-123456 --multi=these are values --state=pending, stopped"
     )
-    assert params_dict.get("state") == "pending,stopped"
-    assert params_dict.get("vm-id") == "i-123456"
-    assert params_dict.get("multi") == "these are values"
-    assert "command" == list_params[0]
-    assert "paramA" == list_params[1]
-    assert "paramB" == list_params[2]
+    assert named_params.get("state") == "pending,stopped"
+    assert named_params.get("vm-id") == "i-123456"
+    assert named_params.get("multi") == "these are values"
+    assert "paramA" == positional_params[0]
+    assert "paramB" == positional_params[1]
 
 
 def test_get_dict_with_flag_parameters():
-    params_dict, list_params = get_sub_commands_and_params(
-        "aws-modify-vm paramA paramB --stop --vm-id=i-123456"
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm modify paramA paramB --stop --vm-id=i-123456"
     )
-    assert params_dict.get("stop") is True
-    assert params_dict.get("vm-id") == "i-123456"
-    assert "aws-modify-vm" == list_params[0]
-    assert "paramA" == list_params[1]
-    assert "paramB" == list_params[2]
+    assert named_params.get("stop") is True
+    assert named_params.get("vm-id") == "i-123456"
+    assert "paramA" == positional_params[0]
+    assert "paramB" == positional_params[1]
 
 
 def test_get_dict_with_multiple_flag_parameters():
-    params_dict, list_params = get_sub_commands_and_params(
-        "command paramA --flag1 --flag2 --value=test"
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm modify paramA --flag1 --flag2 --value=test"
     )
-    assert params_dict.get("flag1") is True
-    assert params_dict.get("flag2") is True
-    assert params_dict.get("value") == "test"
-    assert "command" == list_params[0]
-    assert "paramA" == list_params[1]
+    assert named_params.get("flag1") is True
+    assert named_params.get("flag2") is True
+    assert named_params.get("value") == "test"
+    assert "paramA" == positional_params[0]
 
 
 def test_get_dict_with_only_flag_parameters():
-    params_dict, list_params = get_sub_commands_and_params("command --stop --delete")
-    assert params_dict.get("stop") is True
-    assert params_dict.get("delete") is True
-    assert len(params_dict) == 2
-    assert len(list_params) == 1
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm modify --stop --delete"
+    )
+    assert named_params.get("stop") is True
+    assert named_params.get("delete") is True
+    assert len(named_params) == 2
+    assert len(positional_params) == 0
 
 
 def test_get_list_of_values_for_key_in_dict_of_parameters_when_absent_key():
-    params_dict, list_params = get_sub_commands_and_params("command --stop --delete")
-    result = params_dict.get("absent_key")
+    named_params, positional_params = get_named_and_positional_params(
+        "aws vm modify --stop --delete"
+    )
+    result = named_params.get("absent_key")
     assert result is None
-    assert len(list_params) == 1
+    assert len(positional_params) == 0
 
 
 def test_get_list_of_values_for_key_in_dict_of_parameters_when_present_in_dict_params():

--- a/slack_handlers/handlers.py
+++ b/slack_handlers/handlers.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
             "type": "str",
         }
     },
-    examples=["help", "help create-openstack-vm"],
+    examples=["help", "help openstack vm create"],
 )
 def handle_help(say, user, command_name=None):
     """Handle help command using the new help system."""
@@ -37,7 +37,7 @@ def handle_help(say, user, command_name=None):
 
 # Helper function to handle creating an OpenStack VM
 @command_meta(
-    name="create-openstack-vm",
+    name="openstack vm create",
     description="Create an OpenStack VM with specified configuration",
     arguments={
         "name": {"description": "Name for the VM", "required": True, "type": "str"},
@@ -61,7 +61,7 @@ def handle_help(say, user, command_name=None):
         },
     },
     examples=[
-        "create-openstack-vm --name=myvm --os_name=fedora --flavor=ci.cpu.small --key_pair=new"
+        "openstack vm create --name=myvm --os_name=fedora --flavor=ci.cpu.small --key_pair=new"
     ],
 )
 def handle_create_openstack_vm(say, user, app, params_dict):
@@ -90,7 +90,7 @@ def handle_create_openstack_vm(say, user, app, params_dict):
         if missing_params:
             say(
                 f":warning: Missing required parameters: {', '.join(missing_params)}. "
-                f"Usage: create-openstack-vm --name=<name> --os_name=<os_name> --flavor=<flavor> --key_pair=[new|existing]\n"
+                f"Usage: openstack vm create --name=<name> --os_name=<os_name> --flavor=<flavor> --key_pair=[new|existing]\n"
                 f"Supported OS names: {', '.join(config.OS_IMAGE_MAP.keys())}"
             )
             return
@@ -193,7 +193,7 @@ def handle_create_openstack_vm(say, user, app, params_dict):
 
 # Helper function to list OpenStack VMs with error handling
 @command_meta(
-    name="list-openstack-vms",
+    name="openstack vm list",
     description="List OpenStack VMs with optional status filtering",
     arguments={
         "status": {
@@ -205,9 +205,9 @@ def handle_create_openstack_vm(say, user, app, params_dict):
         }
     },
     examples=[
-        "list-openstack-vms",
-        "list-openstack-vms --status=ACTIVE",
-        "list-openstack-vms --status=SHUTOFF",
+        "openstack vm list",
+        "openstack vm list --status=ACTIVE",
+        "openstack vm list --status=SHUTOFF",
     ],
 )
 def handle_list_openstack_vms(say, params_dict):
@@ -278,7 +278,7 @@ def handle_hello(say, user):
 
 
 @command_meta(
-    name="create-aws-vm",
+    name="aws vm create",
     description="Create an AWS EC2 instance",
     arguments={
         "os_name": {
@@ -301,8 +301,8 @@ def handle_hello(say, user):
         },
     },
     examples=[
-        "create-aws-vm --os_name=linux --instance_type=t2.micro --key_pair=new",
-        "create-aws-vm --os_name=linux --instance_type=t3.small --key_pair=existing",
+        "aws vm create --os_name=linux --instance_type=t2.micro --key_pair=new",
+        "aws vm create --os_name=linux --instance_type=t3.small --key_pair=existing",
     ],
 )
 def handle_create_aws_vm(say, user, region, app, params_dict):
@@ -332,7 +332,7 @@ def handle_create_aws_vm(say, user, region, app, params_dict):
                 missing_params.append("key_pair")
 
             say(
-                f":warning: Missing required parameters: {', '.join(missing_params)}. Usage: create-aws-vm --os_name=<os> --instance_type=<type> --key_pair=<key>"
+                f":warning: Missing required parameters: {', '.join(missing_params)}. Usage: aws vm create --os_name=<os> --instance_type=<type> --key_pair=<key>"
             )
             return
 
@@ -540,7 +540,7 @@ def helper_display_dict_output_as_table(instances_dict, print_keys, say, block_m
 
 # Helper function to list AWS EC2 instances
 @command_meta(
-    name="list-aws-vms",
+    name="aws vm list",
     description="List AWS EC2 instances with optional filtering",
     arguments={
         "state": {
@@ -562,10 +562,10 @@ def helper_display_dict_output_as_table(instances_dict, print_keys, say, block_m
         },
     },
     examples=[
-        "list-aws-vms",
-        "list-aws-vms --state=running,stopped",
-        "list-aws-vms --type=t2.micro,t3.small",
-        "list-aws-vms --instance-ids=i-123456,i-789012",
+        "aws vm list",
+        "aws vm list --state=running,stopped",
+        "aws vm list --type=t2.micro,t3.small",
+        "aws vm list --instance-ids=i-123456,i-789012",
     ],
 )
 def handle_list_aws_vms(say, region, user, params_dict):
@@ -606,7 +606,7 @@ def handle_list_aws_vms(say, region, user, params_dict):
 
 
 @command_meta(
-    name="aws-modify-vm",
+    name="aws vm modify",
     description="Stop or delete AWS EC2 instances",
     arguments={
         "vm-id": {
@@ -622,8 +622,8 @@ def handle_list_aws_vms(say, region, user, params_dict):
         },
     },
     examples=[
-        "aws-modify-vm --stop --vm-id=i-1234567890abcdef0",
-        "aws-modify-vm --delete --vm-id=i-1234567890abcdef0",
+        "aws vm modify --stop --vm-id=i-1234567890abcdef0",
+        "aws vm modify --delete --vm-id=i-1234567890abcdef0",
     ],
 )
 def handle_aws_modify_vm(say, region, user, params_dict):
@@ -642,7 +642,7 @@ def handle_aws_modify_vm(say, region, user, params_dict):
 
         if not vm_id:
             say(
-                ":warning: Missing required parameter `--vm-id`. Usage: `aws-modify-vm --stop --vm-id=<id>` or `aws-modify-vm --delete --vm-id=<id>`"
+                ":warning: Missing required parameter `--vm-id`. Usage: `aws vm modify --stop --vm-id=<id>` or `aws vm modify --delete --vm-id=<id>`"
             )
             return
 
@@ -713,9 +713,9 @@ def handle_aws_modify_vm(say, region, user, params_dict):
 
 # Helper function to list important team links
 @command_meta(
-    name="list-team-links",
+    name="project links list",
     description="Display important team links",
-    examples=["list-team-links"],
+    examples=["project links list"],
 )
 def handle_list_team_links(say, user):
     say(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,5 +22,5 @@ def setup_environment_variables():
     os.environ["OS_APP_CRED_ID"] = "OS_APP_CRED_ID"
     os.environ["OS_APP_CRED_SECRET"] = "OS_APP_CRED_SECRET"
     os.environ["OS_AUTH_TYPE"] = "v3applicationcredential"
-    os.environ["ALLOW_ALL_WORKSPACE_USERS"] = "ALLOW_ALL_WORKSPACE_USERS"
-    os.environ["ALLOWED_SLACK_USERS"] = "ALLOWED_SLACK_USERS"
+    os.environ["ALLOW_ALL_WORKSPACE_USERS"] = "false"
+    os.environ["ALLOWED_SLACK_USERS"] = "false"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -14,3 +14,16 @@ class TestRunner(object):
             f"{outcomes['errors']} unit tests have errors."
         )
         assert "passed" in outcomes.keys(), "No tests passed."
+
+    def test_slack_commands(self, pytester: Pytester) -> None:
+        """Test the slack commands."""
+        pytester.copy_example("tests/test_slack_commands.py")
+        result = pytester.runpytest()
+        outcomes = result.parseoutcomes()
+        assert "failed" not in outcomes.keys(), (
+            f"{outcomes['failed']} unit tests failed."
+        )
+        assert "errors" not in outcomes.keys(), (
+            f"{outcomes['errors']} unit tests have errors."
+        )
+        assert "passed" in outcomes.keys(), "No tests passed."

--- a/tests/test_slack_commands.py
+++ b/tests/test_slack_commands.py
@@ -1,0 +1,161 @@
+import os
+from unittest.mock import MagicMock, patch
+
+os.environ["SLACK_BOT_TOKEN"] = "fake-token-for-testing"
+os.environ["SLACK_APP_TOKEN"] = "fake-token-for-testing"
+
+import sys
+
+with patch("slack_sdk.web.client.WebClient.auth_test", return_value={"ok": True}):
+    if "slack_main" in sys.modules:
+        del sys.modules["slack_main"]
+    from slack_main import mention_handler
+
+
+class MockCommand:
+    """Helper class to create reusable mock setups for commands"""
+
+    @staticmethod
+    def setup_mocks():
+        """Set up all necessary mocks for mention_handler testing - only command handlers"""
+        return {
+            "handle_create_openstack_vm": patch(
+                "slack_main.handle_create_openstack_vm"
+            ),
+            "handle_list_openstack_vms": patch("slack_main.handle_list_openstack_vms"),
+            "handle_hello": patch("slack_main.handle_hello"),
+            "handle_create_aws_vm": patch("slack_main.handle_create_aws_vm"),
+            "handle_list_aws_vms": patch("slack_main.handle_list_aws_vms"),
+            "handle_aws_modify_vm": patch("slack_main.handle_aws_modify_vm"),
+            "handle_list_team_links": patch("slack_main.handle_list_team_links"),
+            "handle_help_command": patch("slack_main.handle_help_command"),
+        }
+
+    @staticmethod
+    def create_mock_body(text="hello", user="U123456"):
+        """Create a mock Slack body event"""
+        return {"event": {"user": user, "text": text}}
+
+
+class TestSlackCommands:
+    """Test class for the slack commands"""
+
+    def setup_method(self):
+        self.mock_say = MagicMock()
+        self.mocks = MockCommand.setup_mocks()
+
+        for mock_name, mock_patch in self.mocks.items():
+            setattr(self, f"mock_{mock_name}", mock_patch.start())
+
+    def teardown_method(self):
+        for mock_patch in self.mocks.values():
+            mock_patch.stop()
+
+    def call_mention_handler(self, command_text, user="U123456"):
+        """Helper method to create body and call mention_handler"""
+        body = MockCommand.create_mock_body(command_text, user)
+        mention_handler(body, self.mock_say)
+
+    def test_hello_command_success(self):
+        """Test successful hello command execution"""
+        self.call_mention_handler("hello")
+
+        self.mock_handle_hello.assert_called_once()
+
+    def test_aws_vm_create_command_success(self):
+        """Test successful AWS VM create command execution"""
+        self.call_mention_handler(
+            "@bot aws vm create --os_name=linux --instance_type=t2.micro --key_pair=new"
+        )
+
+        self.mock_handle_create_aws_vm.assert_called_once()
+
+    def test_openstack_vm_create_command_success(self):
+        """Test successful OpenStack VM create command execution"""
+        self.call_mention_handler(
+            "@bot openstack vm create --name=test --os_name=fedora --flavor=ci.cpu.small --key_pair=new"
+        )
+
+        self.mock_handle_create_openstack_vm.assert_called_once()
+
+    def test_invalid_command(self):
+        """Test invalid command input"""
+        self.call_mention_handler("")
+
+        self.mock_say.assert_called_once()
+        call_args = self.mock_say.call_args[0][0]
+        assert "couldn't understand" in call_args
+        assert "help" in call_args
+
+    def test_unknown_command(self):
+        """Test unknown command handling"""
+        self.call_mention_handler("@bot unknown param")
+
+        self.mock_say.assert_called_once()
+        call_args = self.mock_say.call_args[0][0]
+        assert "couldn't understand" in call_args
+
+    def test_help_flag_command(self):
+        """Test help flag handling"""
+        self.call_mention_handler("@bot aws vm create --help")
+
+        self.mock_handle_help_command.assert_called_once()
+
+    def test_aws_vm_modify_with_multiple_parameters(self):
+        """Test AWS VM modify command with multiple parameters"""
+        self.call_mention_handler("@bot aws vm modify --stop --vm-id=i-123456")
+
+        self.mock_handle_aws_modify_vm.assert_called_once()
+
+    def test_aws_vm_list_with_filters(self):
+        """Test AWS VM list command with filter parameters"""
+        self.call_mention_handler(
+            "@bot aws vm list --state=running,stopped --type=t2.micro"
+        )
+
+        self.mock_handle_list_aws_vms.assert_called_once()
+
+    def test_openstack_vm_list_with_status(self):
+        """Test OpenStack VM list command with status filter"""
+        self.call_mention_handler("@bot openstack vm list --status=ACTIVE")
+
+        self.mock_handle_list_openstack_vms.assert_called_once()
+
+    def test_project_links_list_command(self):
+        """Test project links list command"""
+        self.call_mention_handler("@bot project links list")
+
+        self.mock_handle_list_team_links.assert_called_once_with(
+            self.mock_say, "U123456"
+        )
+
+    def test_command_with_nonexistent_parameters(self):
+        """Test command with non-existent parameters"""
+        self.call_mention_handler(
+            "@bot aws vm create --invalid_param=value --os_name=linux"
+        )
+
+        self.mock_handle_create_aws_vm.assert_called_once()
+
+    def test_command_with_typo(self):
+        """Test command with a typo"""
+        self.call_mention_handler(
+            "aws vm creaate --invalid_param=value --os_name=linux"
+        )
+
+        self.mock_handle_create_aws_vm.assert_not_called()
+        self.mock_say.assert_called_once()
+        call_args = self.mock_say.call_args[0][0]
+        assert "couldn't understand" in call_args
+
+    def test_empty_body_event(self):
+        """Test handling of empty or malformed body event"""
+        body = {}
+
+        mention_handler(body, self.mock_say)
+
+    def test_missing_event_data(self):
+        """Test handling of missing event data"""
+        body = {"event": {}}
+
+        mention_handler(body, self.mock_say)


### PR DESCRIPTION
### What is done?
With these changes all the commands have a single pattern which makes it simple to use and more intuitive.
Check the following example.

**Before**
```
create-aws-vm --os_name=linux --instance_type=t2.micro --key_pair=new
```

**Now**
```
aws vm create --os_name=linux --instance_type=t2.micro --key_pair=new
```

Also, there are changes to the code that improves the code reading and maintenance.