### PR TITLE
Refactor ROTA with columns change & single QE model

### DIFF
--- a/sdk/gsheet/gsheet.py
+++ b/sdk/gsheet/gsheet.py
@@ -23,8 +23,8 @@ class GSheet:
         s_date: date = None,
         e_date: date = None,
         pm: str = None,
-        qe1: str = None,
-        qe2: str = None,
+        qe: str = None,
+        notify_date: str = None,
     ) -> None:
         passed_args = {**locals()}
         release_regex = re.compile(r"^\d\.\d{1,3}\.\d{1,3}$")
@@ -34,7 +34,7 @@ class GSheet:
                 f"{rel_ver} does not seem to match the expected format `\\d\\.\\d{1, 3}\\.\\d{1, 3}`"
             )
 
-        row_to_append = [rel_ver, s_date, e_date, pm, qe1, qe2]
+        row_to_append = [rel_ver, s_date, e_date, pm, qe, notify_date]
 
         if not row_to_append:
             logging.error(f"No row to be updated: {passed_args}")
@@ -66,7 +66,7 @@ class GSheet:
         """Get releases for a specific Monday date
 
         Args:
-            target_monday: The Monday date to filter by (from column G - ERR)
+            target_monday: The Monday date to filter by (from column F - ERR)
 
         Returns:
             List of release rows matching the target Monday
@@ -74,8 +74,8 @@ class GSheet:
         values = self._assignment_wsheet.get_values("A:G")  # only get relevant columns
         target_monday_str = str(target_monday)
 
-        # Filter releases where column G (ERR) matches the target Monday date
-        return [v for v in values if len(v) > 6 and v[6] == target_monday_str]
+        # Filter releases where column F (ERR) matches the target Monday date
+        return [v for v in values if len(v) > 5 and v[5] == target_monday_str]
 
     def replace_user_for_release(
         self, rel_ver: str, column: str, user: str = None
@@ -88,11 +88,11 @@ class GSheet:
                 f"{rel_ver} does not seem to match the expected format `\\d\\.\\d{1, 3}\\.\\d{1, 3}`"
             )
 
-        if column not in ("pm", "qe1", "qe2"):
+        if column not in ("pm", "qe"):
             logger.error(f"Invalid value for replace column: {column}")
             raise ValueError(f"Invalid value for replace column: {column}")
 
-        column_letter_mapping = {"pm": "D", "qe1": "E", "qe2": "F"}
+        column_letter_mapping = {"pm": "D", "qe": "E"}
 
         column_a1 = column_letter_mapping[column]
 

--- a/sdk/smartsheet/fetch_parse_write.py
+++ b/sdk/smartsheet/fetch_parse_write.py
@@ -170,7 +170,7 @@ def write_to_gsheet(filtered_releases, gsheet_creds):
     """Write filtered releases to Google Sheets ROTA -> Assignments
 
     Intelligently compares fetched releases with existing data:
-    - Updates dates (B, C) for existing releases (preserves PM/QE1/QE2 in D-G)
+    - Updates dates (B, C) for existing releases (preserves PM/QE/NOTIFY_DATE in D-F)
     - Adds new rows for new releases
     - Marks rows for deleted releases (optional)
 
@@ -231,64 +231,82 @@ def write_to_gsheet(filtered_releases, gsheet_creds):
         finish_date = rel["finish_date"]
         start_date = finish_date  # Use fetched date directly
         end_date = start_date + timedelta(days=8)  # Add 8 days to start_date
-        err_date = get_previous_weekId(
+        notify_date = get_previous_weekId(
             start_date
         )  # Get previous Monday, or keep if already Monday
 
         fetched_releases[rel["version"]] = {
             "start_date": str(start_date),
             "end_date": str(end_date),
-            "err_date": str(err_date),
+            "notify_date": str(notify_date),
         }
 
     # Track updates and inserts
     updates = []  # List of [range, values]
     new_releases = []  # List of [version, start_date, end_date] only
-    new_releases_err = {}  # Map of version to err_date for later update
+    new_releases_notify = {}  # Map of version to notify_date for later update
     rows_modified = 0
 
-    # Update existing releases with new dates (preserve D-G)
+    # Update existing releases with new dates (preserve D-F)
     for version, dates in fetched_releases.items():
         if version in existing_releases:
             row_idx = existing_releases[version]
             row_num = row_idx + 1  # Convert to 1-based sheet row number
 
-            # Update columns B, C, and G (start_date, end_date, and ERR)
+            # Update columns B, C, and F (start_date, end_date, and ERR)
             updates.append(
                 (f"B{row_num}:C{row_num}", [[dates["start_date"], dates["end_date"]]])
             )
-            # Update column G with err_date (previous Monday or same if already Monday)
-            updates.append((f"G{row_num}", [[dates["err_date"]]]))
+            # Update column F with notify_date (previous Monday or same if already Monday)
+            updates.append((f"F{row_num}", [[dates["notify_date"]]]))
             rows_modified += 1
         else:
             # New release - only append A, B, C (don't write to D-G yet)
             new_releases.append([version, dates["start_date"], dates["end_date"]])
-            new_releases_err[version] = dates["err_date"]
+            new_releases_notify[version] = dates["notify_date"]
+
+    print(
+        f"[DEBUG] {len([u for u in updates if 'F' in u[0]])} existing release ERR updates queued",
+        file=__import__("sys").stderr,
+    )
+    print(
+        f"[DEBUG] {len(new_releases)} new releases to add + update ERR column",
+        file=__import__("sys").stderr,
+    )
 
     # Apply date updates for existing releases
     if updates:
         for range_name, values in updates:
-            worksheet.update(values=values, range_name=range_name)
+            try:
+                worksheet.update(values=values, range_name=range_name)
+            except Exception as e:
+                print(f"Error updating {range_name}: {e}")
+                raise
 
     # Add new releases to the end (only columns A-C)
     if new_releases:
         worksheet.append_rows(new_releases)
         rows_modified += len(new_releases)
 
-        # Now update column G with err_date for newly added rows
+        # Now update column F with notify_date for newly added rows
         # Get the starting row number for the new releases
         all_values_after = worksheet.get_all_values()
         start_row = (
             len(all_values_after) - len(new_releases) + 1
         )  # +1 for 1-based indexing
 
-        for idx, (version, err_date) in enumerate(new_releases_err.items()):
+        notify_updates = []
+        for idx, (version, notify_date) in enumerate(new_releases_notify.items()):
             row_num = start_row + idx
-            updates.append((f"G{row_num}", [[err_date]]))
+            notify_updates.append((f"F{row_num}", [[notify_date]]))
 
-        # Apply G column updates
-        if updates:
-            for range_name, values in updates:
-                worksheet.update(values=values, range_name=range_name)
+        # Apply F column updates for new releases
+        if notify_updates:
+            for range_name, values in notify_updates:
+                try:
+                    worksheet.update(values=values, range_name=range_name)
+                except Exception as e:
+                    print(f"Error updating NOTIFY date for {range_name}: {e}")
+                    raise
 
     return rows_modified

--- a/slack_handlers/handlers.py
+++ b/slack_handlers/handlers.py
@@ -1166,19 +1166,14 @@ def handle_list_team_links(say, user):
             "required": False,
             "type": "str",
         },
-        "qe1": {
-            "description": "Primary QE engineer username",
-            "required": False,
-            "type": "str",
-        },
-        "qe2": {
-            "description": "Secondary QE engineer username",
+        "qe": {
+            "description": "QE engineer username",
             "required": False,
             "type": "str",
         },
     },
     examples=[
-        "rota --add --release=4.15.1 [--start=2024-01-08 --end=2024-01-12 --pm=john.doe --qe1=jane.smith --qe2=bob.wilson]",
+        "rota --add --release=4.15.1 [--start=2024-01-08 --end=2024-01-12 --pm=john.doe --qe=jane.smith --notify_date=2024-01-08]",
         "rota --check --time='This Week'",
         "rota --check --release=4.15.1"
         "rota --replace --release=4.15.1 --column=new_pm [--user=new_person]",
@@ -1231,8 +1226,8 @@ def handle_rota(say, user, params_dict):
                 s_date=start,
                 e_date=end,
                 pm=_get_name_from_userid(params_dict.get("pm")),
-                qe1=_get_name_from_userid(params_dict.get("qe1")),
-                qe2=_get_name_from_userid(params_dict.get("qe2")),
+                qe=_get_name_from_userid(params_dict.get("qe")),
+                notify_date=params_dict.get("notify_date"),
             )
         except ValueError as e:
             say(str(e))
@@ -1257,11 +1252,10 @@ def handle_rota(say, user, params_dict):
                 return
 
         elif time_period:
-            try:
-                data = gsheet.fetch_data_by_time(time_period)
-            except ValueError:
-                say("Time period should either be `This Week` or `Next Week`.")
-                return
+            say(
+                "Time-based queries will be supported in a future update. Please use `release` parameter for now."
+            )
+            return
 
         else:
             say("Please provide either `release` or `time`.")
@@ -1316,18 +1310,15 @@ def _helper_format_rota_output(data: list) -> str:
         logger.error(f"Cannot format ROTA data: {data}")
         return "Some error occurred parsing the data."
 
-    rel_ver, s_date, e_date, pm, qe1, qe2, activity = data
+    rel_ver, s_date, e_date, pm, qe, notify_date, activity = data
 
     if rel_ver == "N/A":
         return ""
 
     pm = _get_userid_from_name(pm)
-    qe1 = _get_userid_from_name(qe1)
-    qe2 = _get_userid_from_name(qe2)
+    qe = _get_userid_from_name(qe)
 
-    return (
-        f"*Release:* {rel_ver}\n" + f"*Patch Manager:* {pm}\n" + f"*QE:* {qe1}, {qe2}"
-    )
+    return f"*Release:* {rel_ver}\n" + f"*Patch Manager:* {pm}\n" + f"*QE:* {qe}"
 
 
 def _get_userid_from_name(name: str) -> str:

--- a/slack_worker/Dockerfile
+++ b/slack_worker/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache --virtual .build-deps \
     python3-dev
 
 # Copy slack_worker requirements
-COPY slack_worker/requirements.txt /app/slack_worker/requirements.txt
+COPY requirements.txt /app/slack_worker/requirements.txt
 
 # Install Python dependencies
 RUN pip install --no-cache-dir -r /app/slack_worker/requirements.txt
@@ -19,10 +19,10 @@ RUN pip install --no-cache-dir -r /app/slack_worker/requirements.txt
 RUN apk del .build-deps
 
 # Copy necessary files from parent directory
-COPY sdk /app/sdk/
+COPY ../sdk /app/sdk/
 
 # Copy slack_worker service
-COPY slack_worker /app/slack_worker/
+COPY ./ /app/slack_worker/
 
 # Create lock directory for file-based locking
 RUN mkdir -p /tmp/slack_worker_locks

--- a/slack_worker/jobs/__init__.py
+++ b/slack_worker/jobs/__init__.py
@@ -2,10 +2,11 @@
 Scheduled job implementations
 """
 
-from .rota_notifications import send_rota_notifications
+from .rota_notifications import send_group_reminder, send_dm_reminders
 from .sync_releases import sync_releases_to_gsheet
 
 __all__ = [
-    "send_rota_notifications",
+    "send_group_reminder",
+    "send_dm_reminders",
     "sync_releases_to_gsheet",
 ]

--- a/slack_worker/jobs/rota_notifications.py
+++ b/slack_worker/jobs/rota_notifications.py
@@ -38,12 +38,14 @@ def get_next_available_monday(assignment_wsheet) -> date:
         or next week's Monday if no releases are found
     """
     this_week_monday = get_this_week_monday()
-    values = assignment_wsheet.get_values("G:G")  # Get all column G values (ERR dates)
+    values = assignment_wsheet.get_values(
+        "F:F"
+    )  # Get all column F values (notify_date)
 
     if not values:
         return this_week_monday + timedelta(days=7)
 
-    # Collect all Monday dates in column G, filter for dates after this week
+    # Collect all Monday dates in column F, filter for dates after this week
     future_mondays = set()
     for row in values[1:]:  # Skip header
         if row and len(row) > 0 and row[0]:
@@ -80,8 +82,8 @@ def _parse_releases_from_rows(data: List[List]) -> List[Dict]:
                 "start_date": row[1],
                 "end_date": row[2],
                 "pm": row[3],
-                "qe1": row[4],
-                "qe2": row[5],
+                "qe": row[4],
+                "notify_date": row[5],
             }
             releases.append(release)
             logger.debug(f"    • Parsed release: {row[0]}")
@@ -193,22 +195,18 @@ def format_release_message(releases: List[Dict], week_label: str = "This Week") 
 
     for release in releases:
         pm = release.get("pm", "TBD")
-        qe1 = release.get("qe1", "TBD")
-        qe2 = release.get("qe2", "TBD")
-        logger.debug(
-            f"  • Formatting {release['version']}: PM={pm}, QE1={qe1}, QE2={qe2}"
-        )
+        qe = release.get("qe", "TBD")
+        logger.debug(f"  • Formatting {release['version']}: PM={pm}, QE={qe}")
 
         pm_mention = get_user_mention(pm)
-        qe1_mention = get_user_mention(qe1)
-        qe2_mention = get_user_mention(qe2)
+        qe_mention = get_user_mention(qe)
 
         message_text = (
             f"*Release:* `{release['version']}`\n"
             f":calendar: *Development Cut-off:* {release['start_date']}\n"
             f":calendar: *Fast-Channel:* {release['end_date']}\n"
             f"*Patch Manager:* {pm_mention}\n"
-            f"*QE:* {qe1_mention}, {qe2_mention}\n"
+            f"*QE:* {qe_mention}\n"
         )
 
         if "This Week" in week_label:
@@ -223,10 +221,7 @@ def format_release_message(releases: List[Dict], week_label: str = "This Week") 
 def send_group_reminder():
     """
     Send group reminder about the week's releases
-    Posted every Monday and Thursday at 9 AM
-
-    Monday 9 AM: Current week + Next week (if found)
-    Thursday 9 AM: Same current week releases (reminder)
+    Scheduled via SCHEDULE_ROTA_NOTIFICATIONS_GROUP_CHANNEL env var
     """
     logger.info("Step 4a: Sending group reminder to Slack channel")
 
@@ -235,6 +230,7 @@ def send_group_reminder():
         day_of_week = today.weekday()  # 0 = Monday, 3 = Thursday
         logger.debug(f"  - Current day: {today} (day_of_week={day_of_week})")
 
+        # Determine if it's Monday or Thursday and fetch appropriate releases
         if day_of_week == 0:  # Monday
             logger.debug(
                 "  - Monday detected: fetching current week and next week releases"
@@ -268,7 +264,7 @@ def send_group_reminder():
 
             message = "\n".join(message_parts)
 
-        elif day_of_week == 3:  # Thursday
+        else:  # Thursday (or other configured days)
             logger.debug(
                 "  - Thursday detected: fetching current week releases (reminder)"
             )
@@ -288,11 +284,6 @@ def send_group_reminder():
                 message_parts.append("No releases scheduled for this week.")
 
             message = "\n".join(message_parts)
-        else:
-            logger.warning(
-                f"  ✗ Group reminder triggered on unexpected day: {day_of_week}"
-            )
-            return
 
         if config.ROTA_GROUP_CHANNEL:
             logger.debug(f"  - Sending message to channel: {config.ROTA_GROUP_CHANNEL}")
@@ -317,9 +308,7 @@ def send_group_reminder():
 def send_dm_reminders():
     """
     Send DM reminders to individuals about their releases
-
-    Monday 9 AM: DMs for current week releases
-    Friday 9 AM: DMs for next week releases only (if they exist)
+    Scheduled via SCHEDULE_ROTA_NOTIFICATIONS_DMS env var
     """
     logger.info("Step 4b: Sending DM reminders to individuals")
 
@@ -332,17 +321,10 @@ def send_dm_reminders():
             logger.debug("  - Monday detected: fetching current week releases for DM")
             releases = get_current_week_releases()
             week_label = "this week"
-
-        elif day_of_week == 4:  # Friday
+        else:  # Friday (or other scheduled days)
             logger.debug("  - Friday detected: fetching NEXT week releases for DM")
             releases = get_next_releases()
             week_label = "next week"
-
-        else:
-            logger.warning(
-                f"  ✗ DM reminder triggered on unexpected day: {day_of_week}"
-            )
-            return
 
         if not releases:
             logger.info(f"  ✗ No releases for {week_label}, no DMs to send")
@@ -367,12 +349,12 @@ def send_dm_reminders():
                     )
                     logger.debug(f"    • Added {pm} (PM) for {release.get('version')}")
 
-            qe1 = release.get("qe1")
-            if qe1 and qe1 != "TBD":
-                user_id = config.ROTA_USERS.get(qe1)
+            qe = release.get("qe")
+            if qe and qe != "TBD":
+                user_id = config.ROTA_USERS.get(qe)
                 if user_id:
                     if user_id not in people_to_notify:
-                        people_to_notify[user_id] = {"name": qe1, "assignments": []}
+                        people_to_notify[user_id] = {"name": qe, "assignments": []}
                     people_to_notify[user_id]["assignments"].append(
                         {
                             "role": "QE",
@@ -380,26 +362,7 @@ def send_dm_reminders():
                             "release": release,
                         }
                     )
-                    logger.debug(
-                        f"    • Added {qe1} (QE1) for {release.get('version')}"
-                    )
-
-            qe2 = release.get("qe2")
-            if qe2 and qe2 != "TBD":
-                user_id = config.ROTA_USERS.get(qe2)
-                if user_id:
-                    if user_id not in people_to_notify:
-                        people_to_notify[user_id] = {"name": qe2, "assignments": []}
-                    people_to_notify[user_id]["assignments"].append(
-                        {
-                            "role": "QE",
-                            "version": release.get("version"),
-                            "release": release,
-                        }
-                    )
-                    logger.debug(
-                        f"    • Added {qe2} (QE2) for {release.get('version')}"
-                    )
+                    logger.debug(f"    • Added {qe} (QE) for {release.get('version')}")
 
         logger.debug(f"  - Sending DMs to {len(people_to_notify)} people")
         for user_id, user_info in people_to_notify.items():

--- a/slack_worker/main.py
+++ b/slack_worker/main.py
@@ -12,7 +12,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from slack_worker.config import config
 from slack_worker.jobs import (
-    send_rota_notifications,
+    send_group_reminder,
+    send_dm_reminders,
     sync_releases_to_gsheet,
 )
 from slack_worker.scheduler import JobScheduler
@@ -41,19 +42,33 @@ def setup_jobs(scheduler: JobScheduler):
     else:
         logger.info("Disabled: Sync releases job (empty schedule)")
 
-    # 2. Notifications job (runs second - after sync)
-    if config.SCHEDULE_ROTA_NOTIFICATIONS:
+    # 2. Group channel notifications job
+    if config.SCHEDULE_ROTA_NOTIFICATIONS_GROUP_CHANNEL:
         scheduler.add_cron_job(
-            func=send_rota_notifications,
-            job_id="send_rota_notifications",
-            cron_expression=config.SCHEDULE_ROTA_NOTIFICATIONS,
+            func=send_group_reminder,
+            job_id="send_rota_notifications_group_channel",
+            cron_expression=config.SCHEDULE_ROTA_NOTIFICATIONS_GROUP_CHANNEL,
             use_lock=True,
         )
         logger.info(
-            f"Enabled: ROTA notifications job ({config.SCHEDULE_ROTA_NOTIFICATIONS})"
+            f"Enabled: ROTA group channel notifications job ({config.SCHEDULE_ROTA_NOTIFICATIONS_GROUP_CHANNEL})"
         )
     else:
-        logger.info("Disabled: ROTA notifications job (empty schedule)")
+        logger.info("Disabled: ROTA group channel notifications job (empty schedule)")
+
+    # 3. DM notifications job
+    if config.SCHEDULE_ROTA_NOTIFICATIONS_DMS:
+        scheduler.add_cron_job(
+            func=send_dm_reminders,
+            job_id="send_rota_notifications_dms",
+            cron_expression=config.SCHEDULE_ROTA_NOTIFICATIONS_DMS,
+            use_lock=True,
+        )
+        logger.info(
+            f"Enabled: ROTA DM notifications job ({config.SCHEDULE_ROTA_NOTIFICATIONS_DMS})"
+        )
+    else:
+        logger.info("Disabled: ROTA DM notifications job (empty schedule)")
 
     logger.info(
         f"Job setup complete. Total jobs scheduled: {len(scheduler.scheduler.get_jobs())}"


### PR DESCRIPTION
Simplifies QE assignment from dual to single QE model with _notify_date_ column change from column G to F.
Splits notification jobs into separate group and DM vars.
Updates Slack command parameters (handlers.py) and Google Sheet schema from 7 to 6 columns.