### PR TITLE
change to version of trivy image

### DIFF
--- a/.github/workflows/create-slackbot-docker-image.yml
+++ b/.github/workflows/create-slackbot-docker-image.yml
@@ -111,7 +111,7 @@ jobs:
         echo "Using Trivy exit code: $EXIT_CODE"
     
         docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-          aquasec/trivy:latest image \
+          aquasec/trivy:0.69.3 image \
           --severity CRITICAL \
           --format table \
           --exit-code $EXIT_CODE \


### PR DESCRIPTION
aquasec/trivy:latest image is no longer supported:
_Using Trivy exit code: 1
Unable to find image 'aquasec/trivy:latest' locally
docker: Error response from daemon: manifest for aquasec/trivy:latest not found: manifest unknown: manifest unknown_

The last known clean release of  trivy on Docker Hub is 0.69.3.